### PR TITLE
chore: 프로젝트 기본 구조 설정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,9 @@ out/
 
 ### VS Code ###
 .vscode/
+
+### Etc ###
+application*.properties
+src/main/resources/config
+logs/*
+.env

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "src/main/resources/config"]
+	path = src/main/resources/config
+	url = https://github.com/MoonBaar/moon-baar-backend-submodule.git

--- a/build.gradle
+++ b/build.gradle
@@ -27,9 +27,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-data-jpa'
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
+	implementation 'org.springframework.boot:spring-boot-starter-validation'
+
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
 	annotationProcessor 'org.projectlombok:lombok'
+
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/src/main/java/com/moonbaar/common/entity/BaseEntity.java
+++ b/src/main/java/com/moonbaar/common/entity/BaseEntity.java
@@ -2,6 +2,9 @@ package com.moonbaar.common.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.EntityListeners;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
 import jakarta.persistence.MappedSuperclass;
 import jakarta.validation.constraints.NotNull;
 import java.time.LocalDateTime;
@@ -13,6 +16,10 @@ import org.springframework.data.jpa.domain.support.AuditingEntityListener;
 @MappedSuperclass
 @EntityListeners(AuditingEntityListener.class)
 public abstract class BaseEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
 
     @NotNull
     @CreatedDate

--- a/src/main/java/com/moonbaar/common/entity/BaseEntity.java
+++ b/src/main/java/com/moonbaar/common/entity/BaseEntity.java
@@ -1,0 +1,21 @@
+package com.moonbaar.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntity {
+
+    @NotNull
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+}

--- a/src/main/java/com/moonbaar/common/entity/BaseEntityWithUpdate.java
+++ b/src/main/java/com/moonbaar/common/entity/BaseEntityWithUpdate.java
@@ -1,0 +1,21 @@
+package com.moonbaar.common.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.EntityListeners;
+import jakarta.persistence.MappedSuperclass;
+import jakarta.validation.constraints.NotNull;
+import java.time.LocalDateTime;
+import lombok.Getter;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public abstract class BaseEntityWithUpdate extends BaseEntity {
+
+    @NotNull
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+}

--- a/src/main/java/com/moonbaar/common/exception/BusinessException.java
+++ b/src/main/java/com/moonbaar/common/exception/BusinessException.java
@@ -1,0 +1,20 @@
+package com.moonbaar.common.exception;
+
+import lombok.Getter;
+
+@Getter
+public class BusinessException extends RuntimeException {
+
+    private final ErrorCode errorCode;
+
+    public BusinessException(ErrorCode errorCode) {
+        super(errorCode.getMessage());
+        this.errorCode = errorCode;
+    }
+
+    public BusinessException(ErrorCode errorCode, Throwable throwable) {
+        super(errorCode.getMessage(), throwable);
+        this.errorCode = errorCode;
+    }
+
+}

--- a/src/main/java/com/moonbaar/common/exception/ErrorCode.java
+++ b/src/main/java/com/moonbaar/common/exception/ErrorCode.java
@@ -1,0 +1,16 @@
+package com.moonbaar.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonFormat;
+import com.fasterxml.jackson.annotation.JsonIgnore;
+import org.springframework.http.HttpStatus;
+
+@JsonFormat(shape = JsonFormat.Shape.OBJECT)
+public interface ErrorCode {
+
+    String getCode();
+
+    String getMessage();
+
+    @JsonIgnore
+    HttpStatus getStatus();
+}

--- a/src/main/java/com/moonbaar/common/exception/ErrorResponse.java
+++ b/src/main/java/com/moonbaar/common/exception/ErrorResponse.java
@@ -1,0 +1,47 @@
+package com.moonbaar.common.exception;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
+import com.fasterxml.jackson.annotation.JsonUnwrapped;
+import com.moonbaar.common.utils.JsonUtils;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import java.util.List;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.FieldError;
+
+public record ErrorResponse(
+        @JsonUnwrapped
+        ErrorCode errorCode,
+
+        @JsonInclude(Include.NON_EMPTY)
+        List<InvalidParam> invalidParams
+) {
+
+    public static ErrorResponse from(ErrorCode errorCode) {
+        return new ErrorResponse(errorCode, null);
+    }
+
+    public static ErrorResponse of(ErrorCode errorCode, List<InvalidParam> invalidParams) {
+        return new ErrorResponse(errorCode, invalidParams);
+    }
+
+    public ResponseEntity<Object> toResponseEntity() {
+        return ResponseEntity.status(errorCode.getStatus()).body(this);
+    }
+
+    public void writeTo(HttpServletResponse response) throws IOException {
+        response.setStatus(errorCode.getStatus().value());
+        response.setContentType(MediaType.APPLICATION_JSON_VALUE);
+        response.setCharacterEncoding("UTF-8");
+        response.getWriter().write(JsonUtils.toJson(this));
+    }
+
+    public record InvalidParam(String name, String reason) {
+
+        public static InvalidParam from(FieldError fieldError) {
+            return new InvalidParam(fieldError.getField(), fieldError.getDefaultMessage());
+        }
+    }
+}

--- a/src/main/java/com/moonbaar/common/exception/GlobalErrorCode.java
+++ b/src/main/java/com/moonbaar/common/exception/GlobalErrorCode.java
@@ -1,0 +1,22 @@
+package com.moonbaar.common.exception;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum GlobalErrorCode implements ErrorCode {
+
+    INTERNAL_SERVER_ERROR("G001", "서버 내부 오류가 발생했습니다.", HttpStatus.INTERNAL_SERVER_ERROR),
+    INVALID_INPUT_VALUE("G002", "잘못된 입력값입니다.", HttpStatus.BAD_REQUEST),
+    RESOURCE_NOT_FOUND("G003", "요청한 리소스를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    METHOD_NOT_ALLOWED("G004", "허용되지 않는 메서드입니다.", HttpStatus.METHOD_NOT_ALLOWED),
+    HANDLE_ACCESS_DENIED("G005", "접근이 거부되었습니다.", HttpStatus.FORBIDDEN),
+    UNAUTHORIZED("G006", "인증되지 않은 사용자입니다.", HttpStatus.UNAUTHORIZED),
+    TOO_MANY_REQUESTS("G007", "과도한 요청을 보내셨습니다. 잠시 기다려 주세요.", HttpStatus.TOO_MANY_REQUESTS);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/common/exception/GlobalExceptionHandler.java
+++ b/src/main/java/com/moonbaar/common/exception/GlobalExceptionHandler.java
@@ -1,0 +1,52 @@
+package com.moonbaar.common.exception;
+
+import com.moonbaar.common.exception.ErrorResponse.InvalidParam;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.context.request.WebRequest;
+import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
+
+@RestControllerAdvice
+public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
+
+    @ExceptionHandler(BusinessException.class)
+    public ResponseEntity<Object> handleBusinessException(BusinessException ex) {
+        return ErrorResponse.from(ex.getErrorCode()).toResponseEntity();
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(
+            MethodArgumentNotValidException ex,
+            HttpHeaders headers,
+            HttpStatusCode status,
+            WebRequest request) {
+        List<InvalidParam> invalidParams = ex.getBindingResult()
+                .getFieldErrors()
+                .stream()
+                .map(ErrorResponse.InvalidParam::from)
+                .toList();
+
+        return ErrorResponse.of(GlobalErrorCode.INVALID_INPUT_VALUE, invalidParams).toResponseEntity();
+    }
+
+    @ExceptionHandler(IllegalArgumentException.class)
+    public ResponseEntity<?> handleIllegalArgumentException(IllegalArgumentException ex) {
+        Map<String, Object> body = new HashMap<>();
+        body.put("message", Collections.singletonList(ex.getMessage()));
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST).body(body);
+    }
+
+    @ExceptionHandler(Exception.class)
+    public ResponseEntity<Object> handleGenericException(Exception ex) {
+        return ErrorResponse.from(GlobalErrorCode.INTERNAL_SERVER_ERROR).toResponseEntity();
+    }
+}

--- a/src/main/java/com/moonbaar/common/utils/JsonUtils.java
+++ b/src/main/java/com/moonbaar/common/utils/JsonUtils.java
@@ -1,0 +1,21 @@
+package com.moonbaar.common.utils;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Component;
+
+@Component
+public class JsonUtils {
+
+    private static ObjectMapper objectMapper;
+
+    @Autowired
+    public void setObjectMapper(ObjectMapper objectMapper) {
+        JsonUtils.objectMapper = objectMapper;
+    }
+
+    public static String toJson(Object object) throws JsonProcessingException {
+        return objectMapper.writeValueAsString(object);
+    }
+}

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,1 +1,0 @@
-spring.application.name=moonbaar


### PR DESCRIPTION
## Issues
close #2 

기본 프로젝트 구조를 설정했습니다.

## Details
- BaseEntity 구현
- BusinessException 구현
- GlobalExceptionHandler 구현
- ErrorResponse 클래스 구현
- 기본 에러 코드 정의
- 데이터 유효성 검증을 위한 spring-boot-starter-validation 의존성 추가
- 설정 파일을 보안을 위해 Git submodule로 분리 (private repository)
  - application*.properties → `src/main/resources/config`로 이동
  - `config` 디렉토리는 Git submodule로 연동
  - 민감한 설정은 `.gitignore`에 등록하여 커밋 제외 처리