### PR TITLE
feat: 행사 목록 조회 api 구현

### DIFF
--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -1,0 +1,24 @@
+package com.moonbaar.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/events/**", "/categories/**", "/districts/**").permitAll()  // 공개 API 경로
+                        .anyRequest().authenticated()  // 나머지 경로는 인증 필요
+                );
+
+        return http.build();
+    }
+}

--- a/src/main/java/com/moonbaar/domain/category/entity/Category.java
+++ b/src/main/java/com/moonbaar/domain/category/entity/Category.java
@@ -1,10 +1,8 @@
 package com.moonbaar.domain.category.entity;
 
+import com.moonbaar.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -19,11 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class Category {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class Category extends BaseEntity {
 
     @NotNull
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/moonbaar/domain/category/entity/Category.java
+++ b/src/main/java/com/moonbaar/domain/category/entity/Category.java
@@ -1,0 +1,31 @@
+package com.moonbaar.domain.category.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "categories")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Category {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/src/main/java/com/moonbaar/domain/district/entity/District.java
+++ b/src/main/java/com/moonbaar/domain/district/entity/District.java
@@ -1,10 +1,8 @@
 package com.moonbaar.domain.district.entity;
 
+import com.moonbaar.common.entity.BaseEntity;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import jakarta.validation.constraints.NotNull;
 import lombok.AccessLevel;
@@ -19,11 +17,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class District {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
+public class District extends BaseEntity {
 
     @NotNull
     @Column(nullable = false, unique = true)

--- a/src/main/java/com/moonbaar/domain/district/entity/District.java
+++ b/src/main/java/com/moonbaar/domain/district/entity/District.java
@@ -1,0 +1,31 @@
+package com.moonbaar.domain.district.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "districts")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class District {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @NotNull
+    @Column(nullable = false, unique = true)
+    private String name;
+}

--- a/src/main/java/com/moonbaar/domain/event/controller/EventController.java
+++ b/src/main/java/com/moonbaar/domain/event/controller/EventController.java
@@ -1,0 +1,77 @@
+package com.moonbaar.domain.event.controller;
+
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.event.dto.EventListResponse;
+import com.moonbaar.domain.event.dto.EventSearchRequest;
+import com.moonbaar.domain.event.exeption.EventErrorCode;
+import com.moonbaar.domain.event.service.EventService;
+import java.time.LocalDate;
+import java.time.format.DateTimeParseException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/events")
+@RequiredArgsConstructor
+public class EventController {
+
+    private final EventService eventService;
+
+    @GetMapping
+    public EventListResponse searchEvents(
+            @RequestParam(required = false) String query,
+            @RequestParam(required = false) Long category,
+            @RequestParam(required = false) Long district,
+            @RequestParam(required = false) String startDate,
+            @RequestParam(required = false) String endDate,
+            @RequestParam(required = false) Boolean isFree,
+            @RequestParam(defaultValue = "startDate") String sort,
+            @RequestParam(defaultValue = "asc") String order,
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "20") int size
+    ) {
+        try {
+            EventSearchRequest request = createSearchRequest(
+                    query, category, district, startDate, endDate,
+                    isFree, sort, order, page, size
+            );
+
+            return eventService.searchEvents(request);
+        } catch (DateTimeParseException e) {
+            throw new BusinessException(EventErrorCode.INVALID_EVENT_PARAMS);
+        }
+    }
+
+    private EventSearchRequest createSearchRequest(
+            String query, Long category, Long district,
+            String startDateStr, String endDateStr,
+            Boolean isFree, String sort, String order,
+            int page, int size
+    ) {
+        LocalDate startDate = parseLocalDate(startDateStr);
+        LocalDate endDate = parseLocalDate(endDateStr);
+
+        validateSearchParameters(page, size);
+
+        return new EventSearchRequest(
+                query, category, district, startDate, endDate,
+                isFree, sort, order, page, size
+        );
+    }
+
+    private LocalDate parseLocalDate(String dateStr) {
+        if (dateStr == null || dateStr.trim().isEmpty()) {
+            return null;
+        }
+        return LocalDate.parse(dateStr);
+    }
+
+    private void validateSearchParameters(int page, int size) {
+        if (page < 1 || size < 1 || size > 100) {
+            throw new BusinessException(EventErrorCode.INVALID_EVENT_PARAMS);
+        }
+    }
+}

--- a/src/main/java/com/moonbaar/domain/event/dto/EventListResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventListResponse.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.event.dto;
+
+import java.util.List;
+
+public record EventListResponse(
+        Long totalCount,
+        int totalPages,
+        int currentPage,
+        List<EventSummaryResponse> events
+) {
+}

--- a/src/main/java/com/moonbaar/domain/event/dto/EventSearchRequest.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventSearchRequest.java
@@ -1,0 +1,17 @@
+package com.moonbaar.domain.event.dto;
+
+import java.time.LocalDate;
+
+public record EventSearchRequest(
+        String query,
+        Long categoryId,
+        Long districtId,
+        LocalDate startDate,
+        LocalDate endDate,
+        Boolean isFree,
+        String sort,
+        String order,
+        int page,
+        int size
+) {
+}

--- a/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
@@ -1,0 +1,20 @@
+package com.moonbaar.domain.event.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record EventSummaryResponse(
+        Long id,
+        String title,
+        String category,
+        String district,
+        String place,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        boolean isFree,
+        String imageUrl,
+        BigDecimal latitude,
+        BigDecimal longitude
+//        boolean isLiked
+) {
+}

--- a/src/main/java/com/moonbaar/domain/event/entity/CulturalEvent.java
+++ b/src/main/java/com/moonbaar/domain/event/entity/CulturalEvent.java
@@ -1,0 +1,106 @@
+package com.moonbaar.domain.event.entity;
+
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "cultural_events", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"title", "start_date"})
+})
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class CulturalEvent {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+
+    @Column(nullable = false)
+    private String title;
+
+    @Column
+    private String place;
+
+    @Column(name = "org_name")
+    private String orgName;
+
+    @Column(name = "use_trgt")
+    private String useTarget;
+
+    @Column(name = "use_fee")
+    private String useFee;
+
+    @Column(columnDefinition = "TEXT")
+    private String player;
+
+    @Column(columnDefinition = "TEXT")
+    private String program;
+
+    @Column(name = "etc_desc", columnDefinition = "TEXT")
+    private String etcDesc;
+
+    @Column(name = "org_link")
+    private String orgLink;
+
+    @Column(name = "main_img")
+    private String mainImg;
+
+    @Column
+    private LocalDate rgstdate;
+
+    @Column
+    private String ticket;
+
+    @Column(name = "start_date", nullable = false)
+    private LocalDateTime startDate;
+
+    @Column(name = "end_date")
+    private LocalDateTime endDate;
+
+    @Column
+    private String themecode;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal latitude;
+
+    @Column(precision = 10, scale = 7)
+    private BigDecimal longitude;
+
+    @Column(name = "is_free")
+    private String isFree;
+
+    @Column(name = "hmpg_addr")
+    private String hmpgAddr;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "category_id")
+    private Category category;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "district_id")
+    private District district;
+
+    @Column(name = "api_last_updated")
+    private LocalDateTime apiLastUpdated;
+}

--- a/src/main/java/com/moonbaar/domain/event/entity/CulturalEvent.java
+++ b/src/main/java/com/moonbaar/domain/event/entity/CulturalEvent.java
@@ -1,13 +1,11 @@
 package com.moonbaar.domain.event.entity;
 
+import com.moonbaar.common.entity.BaseEntityWithUpdate;
 import com.moonbaar.domain.category.entity.Category;
 import com.moonbaar.domain.district.entity.District;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
-import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -29,12 +27,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
-public class CulturalEvent {
-
-    @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private Long id;
-
+public class CulturalEvent extends BaseEntityWithUpdate {
 
     @Column(nullable = false)
     private String title;

--- a/src/main/java/com/moonbaar/domain/event/exeption/EventErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/event/exeption/EventErrorCode.java
@@ -1,0 +1,18 @@
+package com.moonbaar.domain.event.exeption;
+
+import com.moonbaar.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum EventErrorCode implements ErrorCode {
+
+    EVENT_NOT_FOUND("E001", "요청한 행사를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    INVALID_EVENT_PARAMS("E002", "잘못된 행사 검색 파라미터입니다.", HttpStatus.BAD_REQUEST);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/domain/event/repository/CulturalEventRepository.java
+++ b/src/main/java/com/moonbaar/domain/event/repository/CulturalEventRepository.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.event.repository;
+
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.JpaSpecificationExecutor;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CulturalEventRepository extends JpaRepository<CulturalEvent, Long>,
+        JpaSpecificationExecutor<CulturalEvent> {
+}

--- a/src/main/java/com/moonbaar/domain/event/repository/EventSpecifications.java
+++ b/src/main/java/com/moonbaar/domain/event/repository/EventSpecifications.java
@@ -1,0 +1,108 @@
+package com.moonbaar.domain.event.repository;
+
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import jakarta.persistence.criteria.CriteriaBuilder;
+import jakarta.persistence.criteria.CriteriaQuery;
+import jakarta.persistence.criteria.Predicate;
+import jakarta.persistence.criteria.Root;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.data.jpa.domain.Specification;
+
+public class EventSpecifications {
+
+    public static Specification<CulturalEvent> withSearchCriteria(
+            String query,
+            Long categoryId,
+            Long districtId,
+            LocalDate startDate,
+            LocalDate endDate,
+            Boolean isFree
+    ) {
+        return (Root<CulturalEvent> root, CriteriaQuery<?> query1, CriteriaBuilder cb) -> {
+            List<Predicate> predicates = new ArrayList<>();
+
+            addQueryPredicate(query, root, cb, predicates);
+            addCategoryPredicate(categoryId, root, cb, predicates);
+            addDistrictPredicate(districtId, root, cb, predicates);
+            addDatePredicates(startDate, endDate, root, cb, predicates);
+            addFreePredicate(isFree, root, cb, predicates);
+
+            // 종료된 행사는 제외
+            predicates.add(cb.or(
+                    cb.isNull(root.get("endDate")),
+                    cb.greaterThanOrEqualTo(root.get("endDate"), LocalDateTime.now())
+            ));
+
+            return cb.and(predicates.toArray(new Predicate[0]));
+        };
+    }
+
+    private static void addQueryPredicate(
+            String query,
+            Root<CulturalEvent> root,
+            CriteriaBuilder cb,
+            List<Predicate> predicates
+    ) {
+        if (query != null && !query.trim().isEmpty()) {
+            predicates.add(cb.or(
+                    cb.like(cb.lower(root.get("title")), "%" + query.toLowerCase() + "%"),
+                    cb.like(cb.lower(root.get("place")), "%" + query.toLowerCase() + "%")
+            ));
+        }
+    }
+
+    private static void addCategoryPredicate(
+            Long categoryId,
+            Root<CulturalEvent> root,
+            CriteriaBuilder cb,
+            List<Predicate> predicates
+    ) {
+        if (categoryId != null) {
+            predicates.add(cb.equal(root.get("category").get("id"), categoryId));
+        }
+    }
+
+    private static void addDistrictPredicate(
+            Long districtId,
+            Root<CulturalEvent> root,
+            CriteriaBuilder cb,
+            List<Predicate> predicates
+    ) {
+        if (districtId != null) {
+            predicates.add(cb.equal(root.get("district").get("id"), districtId));
+        }
+    }
+
+    private static void addDatePredicates(
+            LocalDate startDate,
+            LocalDate endDate,
+            Root<CulturalEvent> root,
+            CriteriaBuilder cb,
+            List<Predicate> predicates
+    ) {
+        if (startDate != null) {
+            LocalDateTime startDateTime = startDate.atStartOfDay();
+            predicates.add(cb.greaterThanOrEqualTo(root.get("startDate"), startDateTime));
+        }
+
+        if (endDate != null) {
+            LocalDateTime endDateTime = endDate.plusDays(1).atStartOfDay();
+            predicates.add(cb.lessThan(root.get("startDate"), endDateTime));
+        }
+    }
+
+    private static void addFreePredicate(
+            Boolean isFree,
+            Root<CulturalEvent> root,
+            CriteriaBuilder cb,
+            List<Predicate> predicates
+    ) {
+        if (isFree != null) {
+            String freeValue = isFree ? "무료" : "유료";
+            predicates.add(cb.equal(root.get("isFree"), freeValue));
+        }
+    }
+}

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -1,0 +1,110 @@
+package com.moonbaar.domain.event.service;
+
+import com.moonbaar.domain.event.dto.EventListResponse;
+import com.moonbaar.domain.event.dto.EventSearchRequest;
+import com.moonbaar.domain.event.dto.EventSummaryResponse;
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.event.repository.CulturalEventRepository;
+import com.moonbaar.domain.event.repository.EventSpecifications;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.jpa.domain.Specification;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EventService {
+
+    private final CulturalEventRepository eventRepository;
+
+    public EventListResponse searchEvents(EventSearchRequest request) {
+        Specification<CulturalEvent> spec = createSearchSpecification(request);
+        Pageable pageable = createPageableWithSort(request);
+
+        Page<CulturalEvent> eventPage = eventRepository.findAll(spec, pageable);
+        List<EventSummaryResponse> eventResponses = mapToEventResponses(eventPage.getContent());
+
+        return createEventListResponse(eventPage, eventResponses);
+    }
+
+    private Specification<CulturalEvent> createSearchSpecification(EventSearchRequest request) {
+        return EventSpecifications.withSearchCriteria(
+                request.query(),
+                request.categoryId(),
+                request.districtId(),
+                request.startDate(),
+                request.endDate(),
+                request.isFree()
+        );
+    }
+
+    private Pageable createPageableWithSort(EventSearchRequest request) {
+        Sort sort = createSortCriteria(request.sort(), request.order());
+        return PageRequest.of(request.page() - 1, request.size(), sort);
+    }
+
+    private Sort createSortCriteria(String sortBy, String order) {
+        Sort.Direction direction = "desc".equalsIgnoreCase(order)
+                ? Sort.Direction.DESC
+                : Sort.Direction.ASC;
+
+        String sortProperty = determineSortProperty(sortBy);
+        return Sort.by(direction, sortProperty);
+    }
+
+    private String determineSortProperty(String sortBy) {
+        if ("popularity".equals(sortBy)) {
+            return "id"; // 임시로 id로 정렬(인기도 정렬은 추후 방문수와 좋아요 수 기준으로 확장)
+        }
+        return "startDate"; // 기본값은 시작일
+    }
+
+    private List<EventSummaryResponse> mapToEventResponses(List<CulturalEvent> events) {
+        return events.stream()
+                .map(event -> mapToEventResponse(event))
+                .toList();
+    }
+
+    private EventSummaryResponse mapToEventResponse(CulturalEvent event) {
+//        boolean isLiked = checkIfEventIsLiked(event.getId(), userId);
+        boolean isFreeEvent = "무료".equals(event.getIsFree());
+
+        return new EventSummaryResponse(
+                event.getId(),
+                event.getTitle(),
+                Optional.ofNullable(event.getCategory()).map(c -> c.getName()).orElse(null),
+                Optional.ofNullable(event.getDistrict()).map(d -> d.getName()).orElse(null),
+                event.getPlace(),
+                event.getStartDate(),
+                event.getEndDate(),
+                isFreeEvent,
+                event.getMainImg(),
+                event.getLatitude(),
+                event.getLongitude()
+//                isLiked
+        );
+    }
+
+//    private boolean checkIfEventIsLiked(Long eventId, Long userId) {
+//        if (userId == null) {
+//            return false;
+//        }
+//        return likedEventRepository.existsByEventIdAndUserId(eventId, userId);
+//    }
+
+    private EventListResponse createEventListResponse(Page<CulturalEvent> eventPage, List<EventSummaryResponse> eventResponses) {
+        return new EventListResponse(
+                eventPage.getTotalElements(),
+                eventPage.getTotalPages(),
+                eventPage.getNumber() + 1,
+                eventResponses
+        );
+    }
+}

--- a/src/test/java/com/moonbaar/domain/event/repository/CulturalEventRepositoryTest.java
+++ b/src/test/java/com/moonbaar/domain/event/repository/CulturalEventRepositoryTest.java
@@ -1,0 +1,38 @@
+package com.moonbaar.domain.event.repository;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE) // 실제 DB 사용
+public class CulturalEventRepositoryTest {
+
+    @Autowired
+    private CulturalEventRepository eventRepository;
+
+    @Test
+    public void testFindAll() {
+        // 기본 findAll 테스트
+        Page<CulturalEvent> events = eventRepository.findAll(PageRequest.of(0, 10));
+
+        // 결과 출력
+        System.out.println("Total events: " + events.getTotalElements());
+        events.getContent().forEach(event -> {
+            System.out.println("Event ID: " + event.getId());
+            System.out.println("Title: " + event.getTitle());
+            System.out.println("Start Date: " + event.getStartDate());
+            System.out.println("End Date: " + event.getEndDate());
+            System.out.println("-------------------");
+        });
+
+        // 기본 검증
+        assertThat(events).isNotNull();
+    }
+}


### PR DESCRIPTION
## 이슈
- #4 

## 주요 변경 사항
> 서울시 공공데이터 API를 활용한 문화행사 정보를 검색하고 조회할 수 있는 API를 구현했습니다. 현재 user 관련 코드가 구현되지 않아 유저 정보가 필요한 목록은 빼고 응답을 하도록 구현했습니다.

1. **문화행사 관련 엔티티 구현**
   - `CulturalEvent`, `Category`, `District` 엔티티 구현
   - 파이썬 스크립트로 생성된 DB 스키마와 일치하도록 `BaseEntity` 상속 제거
   
2. **JPA Specification을 활용한 동적 검색 쿼리 구현**
   - 다양한 검색 조건(키워드, 카테고리, 지역, 날짜, 무료/유료)에 따른 동적 쿼리 생성
   - 각 검색 조건별 Predicate 생성 메서드 분리
   
3. **문화행사 목록 조회 API 개발**
   - `GET /events` 엔드포인트 구현
   - 페이징, 정렬 기능 구현
   - Spring Security 설정으로 인증 없이 접근 가능하도록 설정

4. **DTO, 서비스, 컨트롤러 구현**

## 세부 설명
이번 구현을 통해 JPA Specification 패턴에 대해 공부할 수 있었습니다.

원래는 복잡한 쿼리를 작성할 때 JPQL을 직접 사용하는 방법만 알고 있었습니다. 그러나 검색어, 카테고리, 지역, 날짜, 무료/유료 등 다양한 검색 조건이 선택적으로 적용되는 동적 쿼리의 경우, JPQL 사용이 복잡하고 오류 가능성이 높아 JPA Specification 이나 QueryDSL 패턴을 사용한다는 것을 알게됐습니다.

따라서 JPA Specification 패턴을 적용하여 조회 로직을 구현했습니다.

JPA Specification은 Spring Data JPA에서 제공하는 기능으로, 복잡한 검색 조건을 객체 지향적으로 구성할 수 있게 해줍니다. 특히 동적 쿼리 생성에 유용하며, 다음과 같은 방식으로 구현했습니다:

```java
public static Specification<CulturalEvent> withSearchCriteria(
        String query, Long categoryId, Long districtId, 
        LocalDate startDate, LocalDate endDate, Boolean isFree) {
    return (Root<CulturalEvent> root, CriteriaQuery<?> query1, CriteriaBuilder cb) -> {
        List<Predicate> predicates = new ArrayList<>();
        // 각 조건에 맞는 Predicate 추가
        return cb.and(predicates.toArray(new Predicate[0]));
    };
}
```

하지만 찾다보니 실무에서는 JPA Specification은 복잡하기 때문에 쓰지 않고 QueryDSL을 더 많이 사용한다는 것을 알게 되었습니다. 
https://velog.io/@jun-k0/스프링부트-JPA-Specification

QueryDSL은 타입 안전성과 더 직관적인 인터페이스를 제공하기 때문에, QueryDSL로 마이그레이션할 예정입니다.

또한 구현 과정에서 Spring Security의 기본 설정이 OAuth 의존성으로 인해 모든 API 경로에 인증을 요구하는 문제가 있었습니다.
이를 해결하기 위해 SecurityConfig 클래스를 구현하여 문화행사 API는 인증 없이 접근 가능하도록 설정했습니다.

## API 응답 예시

``` json
{
    "totalCount": 30,
    "totalPages": 2,
    "currentPage": 1,
    "events": [
        {
            "id": 30,
            "title": "[서울시립 북서울미술관] 청소년 전시 감상 프로그램 [학교 옆 미술관]",
            "category": "교육/체험",
            "district": "노원구",
            "place": "서울시립 북서울미술관 전시실(서울특별시 노원구 동일로 1238)",
            "startDate": "2025-05-07T00:00:00",
            "endDate": "2025-07-31T00:00:00",
            "isFree": true,
            "imageUrl": "https://culture.seoul.go.kr/cmmn/file/getImage.do?atchFileId=ff79f450e1f84e86811f830f4d1fb88d&thumb=Y",
            "latitude": 37.6406605,
            "longitude": 127.0668656
        },
       {
          ....
       }, ....
    ]
}
...
```

## 다음 작업
- JPA Specification에서 QueryDSL로 마이그레이션
- 좋아요/방문 기능 구현
- 행사 상세 조회 API 개발