### PR TITLE
feat: 행사 상세 조회 api 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,111 @@
+name: Deploy to Development Server
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    environment: development
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          submodules: true
+          token: ${{ secrets.GH_PAT }}
+      
+      # Gradle 캐시 설정
+      - name: Setup Gradle cache
+        uses: actions/cache@v3
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: ${{ runner.os }}-gradle-
+
+      # 서브모듈 설정
+      - name: Setup submodule
+        run: |
+          cd src/main/resources/config
+          git pull
+          cd ../../../../
+
+      # GitHub Container Registry 로그인
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GH_PAT }}
+      
+      # 도커 빌더 설정
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      # Backend 이미지 빌드 및 푸시
+      - name: Build and push Backend image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          file: docker-files/backend/Dockerfile
+          push: true
+          tags: ${{ secrets.BACKEND_IMAGE }}
+          platforms: linux/arm64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      # 필요한 파일만 서버로 전송
+      - name: Copy deployment files
+        uses: appleboy/scp-action@v0.1.7
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          source: "docker-compose.yml,docker-files/nginx/"
+          target: "${{ secrets.DEPLOY_PATH }}"
+          strip_components: 0
+
+      # 백엔드 배포
+      - name: Deploy backend
+        uses: appleboy/ssh-action@v1.0.3
+        with:
+          host: ${{ secrets.HOST }}
+          port: ${{ secrets.PORT }}
+          username: ${{ secrets.USERNAME }}
+          key: ${{ secrets.SSH_PRIVATE_KEY }}
+          script: |
+            cd ${{ secrets.DEPLOY_PATH }}
+
+            # GitHub Container Registry 로그인 추가
+            echo ${{ secrets.GH_PAT }} | docker login ghcr.io -u ${{ github.actor }} --password-stdin
+            
+            # 환경 변수 파일 생성
+            cat > .env << EOL
+            DB_ROOT_PASSWORD=${{ secrets.DB_ROOT_PASSWORD }}
+            DB_HOST=${{ secrets.DB_HOST }}
+            DB_NAME=${{ secrets.DB_NAME }}
+            DB_USER=${{ secrets.DB_USER }}
+            DB_PASSWORD=${{ secrets.DB_PASSWORD }}
+            DOMAIN_NAME=${{ secrets.DOMAIN_NAME }}
+            BACKEND_PORT=${{ secrets.BACKEND_PORT }}
+            NGINX_PORT=${{ secrets.NGINX_PORT }}
+            DB_PORT=${{ secrets.DB_PORT }}
+            BACKEND_IMAGE=${{ secrets.BACKEND_IMAGE }}
+            SEOUL_API_KEY=${{ secrets.SEOUL_API_KEY }}
+            EOL
+
+            # 백엔드만 재배포
+            docker-compose pull backend
+            docker-compose up -d --no-deps backend
+            
+            # 상태 확인
+            docker-compose ps
+            
+            # 미사용 이미지 정리
+            docker image prune -f --filter "until=168h"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,79 @@
+services:
+  nginx:
+    image: nginx:alpine
+    container_name: mb-nginx
+    depends_on:
+      backend:
+        condition: service_started
+    ports:
+      - "${NGINX_PORT}:80"
+    volumes:
+      - ./docker-files/nginx/nginx.conf:/etc/nginx/conf.d/default.conf
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  data-init:
+    build:
+      context: ./docker-files/data-init
+      dockerfile: Dockerfile
+    container_name: mb-data-init
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    environment:
+      DB_HOST: ${DB_HOST}
+      DB_USER: ${DB_USER}
+      DB_PASSWORD: ${DB_PASSWORD}
+      DB_NAME: ${DB_NAME}
+      SEOUL_API_KEY: ${SEOUL_API_KEY}
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  mariadb:
+    image: mariadb:latest
+    container_name: mb-mariadb
+    healthcheck:
+      test: ["CMD", "mariadb", "-h", "localhost", "-u${DB_USER}", "-p${DB_PASSWORD}", "-e", "SELECT 1"]
+      start_period: 30s
+      interval: 10s
+      timeout: 5s
+      retries: 5
+    environment:
+      MARIADB_ROOT_PASSWORD: ${DB_ROOT_PASSWORD}
+      MARIADB_DATABASE: ${DB_NAME}
+      MARIADB_USER: ${DB_USER}
+      MARIADB_PASSWORD: ${DB_PASSWORD}
+    ports:
+      - "${DB_PORT}:3306"
+    volumes:
+      - mariadb-data:/var/lib/mysql
+    networks:
+      - app-network
+    restart: unless-stopped
+
+  backend:
+    image: ${BACKEND_IMAGE}
+    platform: linux/arm64
+    container_name: mb-backend
+    depends_on:
+      mariadb:
+        condition: service_healthy
+    environment:
+      - DB_HOST=${DB_HOST}
+      - DB_NAME=${DB_NAME}
+      - DB_USER=${DB_USER}
+      - DB_PASSWORD=${DB_PASSWORD}
+    ports:
+      - "${BACKEND_PORT}:8080"
+    networks:
+      - app-network
+    restart: unless-stopped
+
+networks:
+  app-network:
+    driver: bridge
+
+volumes:
+  mariadb-data:

--- a/docker-files/backend/Dockerfile
+++ b/docker-files/backend/Dockerfile
@@ -1,0 +1,23 @@
+# 빌드 스테이지
+FROM amazoncorretto:17-alpine as build
+
+WORKDIR /workspace/app
+
+COPY gradle gradle
+COPY build.gradle settings.gradle gradlew ./
+COPY src src
+
+RUN chmod +x ./gradlew
+RUN ./gradlew bootJar
+RUN mkdir -p build/libs
+
+# 실행 스테이지
+FROM amazoncorretto:17-alpine
+
+VOLUME /tmp
+
+COPY --from=build /workspace/app/build/libs/*.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "/app.jar"]

--- a/docker-files/data-init/Dockerfile
+++ b/docker-files/data-init/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y bash
+
+COPY requirements.txt .
+COPY get_cultural_events.py .
+RUN pip install -r requirements.txt
+
+COPY . .
+
+CMD ["tail", "-f", "/dev/null"]

--- a/docker-files/data-init/get_cultural_events.py
+++ b/docker-files/data-init/get_cultural_events.py
@@ -1,0 +1,314 @@
+import requests
+import pymysql
+from datetime import datetime
+import math
+import os
+
+# API 요청 함수
+def fetch_cultural_events(api_key, start_index, end_index):
+    url = "http://openapi.seoul.go.kr:8088"
+    endpoint = f"{url}/{api_key}/json/culturalEventInfo/{start_index}/{end_index}"
+
+    try:
+        response = requests.get(endpoint)
+        response.raise_for_status()
+
+        data = response.json()
+        return data['culturalEventInfo']['row']
+    except Exception as e:
+        print(f"API 요청 중 오류 발생 (인덱스 {start_index}-{end_index}): {e}")
+        return []
+
+# 카테고리 ID 가져오기 (없으면 생성)
+def get_or_create_category(cursor, category_name):
+    if not category_name or category_name.strip() == '':
+        category_name = '기타'
+
+    query = "SELECT id FROM categories WHERE name = %s"
+    cursor.execute(query, (category_name,))
+    result = cursor.fetchone()
+
+    if result:
+        return result[0]
+
+    # 새 카테고리 생성
+    current_time = datetime.now()
+    insert_query = "INSERT INTO categories (name, created_at) VALUES (%s, %s)"
+    cursor.execute(insert_query, (category_name, current_time))
+    return cursor.lastrowid
+
+# 행정구 ID 가져오기 (없으면 생성)
+def get_or_create_district(cursor, district_name):
+    if not district_name or district_name.strip() == '':
+        district_name = '기타'
+
+    query = "SELECT id FROM districts WHERE name = %s"
+    cursor.execute(query, (district_name,))
+    result = cursor.fetchone()
+
+    if result:
+        return result[0]
+
+    # 새 행정구 생성
+    current_time = datetime.now()
+    insert_query = "INSERT INTO districts (name, created_at) VALUES (%s, %s)"
+    cursor.execute(insert_query, (district_name, current_time))
+    return cursor.lastrowid
+
+# 문화행사 삽입 또는 업데이트
+def insert_or_update_event(cursor, event, category_id, district_id):
+    # 동일 행사가 있는지 확인 (title과 start_date로 판단)
+    check_query = """
+    SELECT id FROM cultural_events 
+    WHERE title = %s AND start_date = %s
+    """
+
+    start_date = parse_date(event.get('STRTDATE', ''))
+    if not start_date:
+        start_date = datetime.now()
+
+    cursor.execute(check_query, (event.get('TITLE', ''), start_date))
+    existing = cursor.fetchone()
+
+    current_time = datetime.now()
+
+    if existing:
+        # 이미 존재하는 행사 업데이트
+        update_query = """
+        UPDATE cultural_events SET
+            place = %s,
+            org_name = %s,
+            use_trgt = %s,
+            use_fee = %s,
+            player = %s,
+            program = %s,
+            etc_desc = %s,
+            org_link = %s,
+            main_img = %s,
+            rgstdate = %s,
+            ticket = %s,
+            end_date = %s,
+            themecode = %s,
+            latitude = %s,
+            longitude = %s,
+            is_free = %s,
+            hmpg_addr = %s,
+            category_id = %s,
+            district_id = %s,
+            api_last_updated = %s,
+            updated_at = %s
+        WHERE id = %s
+        """
+
+        params = (
+            event.get('PLACE', ''),
+            event.get('ORG_NAME', ''),
+            event.get('USE_TRGT', ''),
+            event.get('USE_FEE', ''),
+            event.get('PLAYER', ''),
+            event.get('PROGRAM', ''),
+            event.get('ETC_DESC', ''),
+            event.get('ORG_LINK', ''),
+            event.get('MAIN_IMG', ''),
+            parse_date(event.get('RGSTDATE', '')),
+            event.get('TICKET', ''),
+            parse_date(event.get('END_DATE', '')),
+            event.get('THEMECODE', ''),
+            float(event.get('LOT', 0) or 0),
+            float(event.get('LAT', 0) or 0),
+            event.get('IS_FREE', ''),
+            event.get('HMPG_ADDR', ''),
+            category_id,
+            district_id,
+            current_time,  # api_last_updated
+            current_time,  # updated_at
+            existing[0]
+        )
+
+        cursor.execute(update_query, params)
+        return existing[0], "updated"
+
+    else:
+        # 새 행사 삽입
+        insert_query = """
+        INSERT INTO cultural_events (
+            title, place, org_name, use_trgt, use_fee, 
+            player, program, etc_desc, org_link, main_img,
+            rgstdate, ticket, start_date, end_date, themecode,
+            latitude, longitude, is_free, hmpg_addr, 
+            category_id, district_id, api_last_updated,
+            created_at, updated_at
+        ) VALUES (
+            %s, %s, %s, %s, %s, 
+            %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, %s,
+            %s, %s, %s, %s, 
+            %s, %s, %s, %s, %s
+        )
+        """
+
+        params = (
+            event.get('TITLE', ''),
+            event.get('PLACE', ''),
+            event.get('ORG_NAME', ''),
+            event.get('USE_TRGT', ''),
+            event.get('USE_FEE', ''),
+            event.get('PLAYER', ''),
+            event.get('PROGRAM', ''),
+            event.get('ETC_DESC', ''),
+            event.get('ORG_LINK', ''),
+            event.get('MAIN_IMG', ''),
+            parse_date(event.get('RGSTDATE', '')),
+            event.get('TICKET', ''),
+            start_date,
+            parse_date(event.get('END_DATE', '')),
+            event.get('THEMECODE', ''),
+            float(event.get('LOT', 0) or 0),
+            float(event.get('LAT', 0) or 0),
+            event.get('IS_FREE', ''),
+            event.get('HMPG_ADDR', ''),
+            category_id,
+            district_id,
+            current_time,  # api_last_updated
+            current_time,  # created_at
+            current_time   # updated_at
+        )
+
+        cursor.execute(insert_query, params)
+        return cursor.lastrowid, "inserted"
+
+# 날짜 문자열 파싱 함수
+def parse_date(date_str):
+    if not date_str or date_str.strip() == '':
+        return None
+
+    try:
+        # API 응답의 날짜 형식에 맞게 파싱
+        if 'T' in date_str:  # ISO 형식 (2025-03-28T14:30:00)
+            return datetime.fromisoformat(date_str.replace('Z', '+00:00'))
+        elif ' ' in date_str and '.' in date_str:  # 2025-05-08 00:00:00.0 형식
+            # 밀리초 부분(.0)을 제거하고 처리
+            clean_date_str = date_str.split('.')[0]
+            return datetime.strptime(clean_date_str, '%Y-%m-%d %H:%M:%S')
+        elif ' ' in date_str:  # 2025-05-08 00:00:00 형식
+            return datetime.strptime(date_str, '%Y-%m-%d %H:%M:%S')
+        elif '-' in date_str:  # YYYY-MM-DD 형식
+            return datetime.strptime(date_str, '%Y-%m-%d')
+        else:  # YYYYMMDD 형식
+            return datetime.strptime(date_str, '%Y%m%d')
+    except ValueError:
+        # print(f"날짜 파싱 오류: {date_str}")
+        return None
+
+# 메인 함수
+def main():
+    # 설정
+    API_KEY = os.getenv('SEOUL_API_KEY')  # 서울시 공공데이터 포털에서 발급받은 API 키로 변경
+    DB_CONFIG = {
+        'host': os.getenv('DB_HOST'),
+        'user': os.getenv('DB_USER'),  # 설정한 user로 변경
+        'password': os.getenv('DB_PASSWORD'),  # 설정한 비밀번호로 변경
+        'db': os.getenv('DB_NAME'),  # 설정한 db로 변경
+        'charset': 'utf8mb4'
+    }
+
+    # 환경 변수 디버깅
+    print(f"환경 변수 확인: DB_HOST={os.getenv('DB_HOST')}, DB_USER={os.getenv('DB_USER')}, DB_NAME={os.getenv('DB_NAME')}, API_KEY={API_KEY != None}")
+
+    # 데이터 가져올 인덱스 범위
+    START_INDEX = 1
+    END_INDEX = 1000  # 원하는 최종 인덱스로 변경, 예: 5000
+
+    # 배치 사이즈 설정 (API 최대 허용: 1000)
+    BATCH_SIZE = 1000
+
+    # 전체 레코드 수
+    total_records = END_INDEX - START_INDEX + 1
+
+    # 배치 수 계산
+    num_batches = math.ceil(total_records / BATCH_SIZE)
+
+    print(f"총 {total_records}개 레코드를 {num_batches}개 배치로 처리합니다. (배치 크기: {BATCH_SIZE})")
+
+    # 데이터베이스 연결
+    connection = pymysql.connect(**DB_CONFIG)
+
+    try:
+        with connection.cursor() as cursor:
+            # 테이블 생성 로직을 생략 (이미 Spring에 의해 생성됨)
+            print("테이블이 이미 존재하므로 테이블 생성 과정을 건너뜁니다.")
+
+            # 결과 통계
+            total_inserted = 0
+            total_updated = 0
+            total_processed = 0
+
+            # 배치 처리
+            for batch in range(num_batches):
+                batch_start = START_INDEX + (batch * BATCH_SIZE)
+                batch_end = min(START_INDEX + ((batch + 1) * BATCH_SIZE) - 1, END_INDEX)
+
+                print(f"배치 {batch + 1}/{num_batches} 처리 중 (인덱스: {batch_start}-{batch_end})...")
+
+                # API 요청 및 데이터 가져오기
+                events = fetch_cultural_events(API_KEY, batch_start, batch_end)
+
+                if not events:
+                    print(f"배치 {batch + 1}: 가져온 행사 정보가 없습니다.")
+                    continue
+
+                # 각 행사 처리
+                batch_results = []
+
+                for event in events:
+                    try:
+                        # 카테고리 확인 및 생성
+                        category_name = event.get('CODENAME', '기타')
+                        category_id = get_or_create_category(cursor, category_name)
+
+                        # 행정구역 확인 및 생성
+                        district_name = event.get('GUNAME', '기타')
+                        district_id = get_or_create_district(cursor, district_name)
+
+                        # 행사 삽입 또는 업데이트
+                        event_id, status = insert_or_update_event(cursor, event, category_id, district_id)
+
+                        batch_results.append({
+                            'id': event_id,
+                            'title': event.get('TITLE', ''),
+                            'status': status
+                        })
+
+                    except Exception as e:
+                        print(f"행사 처리 중 오류 발생: {e}")
+
+                # 배치 결과 커밋
+                connection.commit()
+
+                # 배치 결과 통계
+                batch_inserted = sum(1 for r in batch_results if r['status'] == 'inserted')
+                batch_updated = sum(1 for r in batch_results if r['status'] == 'updated')
+
+                print(f"배치 {batch + 1} 결과: 총 {len(batch_results)}개 행사 처리")
+                print(f"- 삽입: {batch_inserted}개")
+                print(f"- 업데이트: {batch_updated}개")
+
+                # 전체 통계 업데이트
+                total_inserted += batch_inserted
+                total_updated += batch_updated
+                total_processed += len(batch_results)
+
+            # 최종 결과 출력
+            print("\n--- 최종 처리 결과 ---")
+            print(f"총 처리된 행사: {total_processed}개")
+            print(f"- 새로 삽입: {total_inserted}개")
+            print(f"- 업데이트: {total_updated}개")
+
+    except Exception as e:
+        print(f"데이터베이스 작업 중 오류 발생: {e}")
+        connection.rollback()
+    finally:
+        connection.close()
+
+if __name__ == "__main__":
+    main()

--- a/docker-files/data-init/requirements.txt
+++ b/docker-files/data-init/requirements.txt
@@ -1,0 +1,2 @@
+requests
+pymysql

--- a/docker-files/nginx/conf/default.conf
+++ b/docker-files/nginx/conf/default.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name ${DOMAIN_NAME};
+
+    location / {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/docker-files/nginx/nginx.conf
+++ b/docker-files/nginx/nginx.conf
@@ -1,0 +1,12 @@
+server {
+    listen 80;
+    server_name ${DOMAIN_NAME};
+
+    location / {
+        proxy_pass http://backend:8080;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}

--- a/scripts/set-github-secrets.sh
+++ b/scripts/set-github-secrets.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# ANSI 색상 코드
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m' # No Color
+
+# 사용법 체크
+if [ -z "$1" ]; then
+   echo "${RED}Usage: ./set-github-env-secrets.sh <environment_name>${NC}"
+   echo "${YELLOW}Example: ./set-github-env-secrets.sh development${NC}"
+   exit 1
+fi
+
+ENVIRONMENT=$1
+
+# Environment secrets 설정
+echo "⚙️ ${GREEN}GitHub ${ENVIRONMENT} environment secrets 설정을 시작합니다...${NC}"
+
+# .env 파일이 존재하는지 확인
+if [ ! -f .env ]; then
+   echo "${RED}Error: .env 파일을 찾을 수 없습니다.${NC}"
+   exit 1
+fi
+
+# .env 파일을 읽어서 secrets 설정
+while IFS='=' read -r key value
+do
+   if [ ! -z "$key" ] && [ ! -z "$value" ]; then
+       gh secret set "$key" -b"$value" --env $ENVIRONMENT || exit 1
+   fi
+done < .env
+
+# SSH key 설정 (선택적)
+if [ -f ~/.ssh/id_ed25519 ]; then
+   gh secret set SSH_PRIVATE_KEY -b"$(cat ~/.ssh/id_ed25519)" --env $ENVIRONMENT || exit 1
+fi
+
+echo "✅ ${GREEN}GitHub ${ENVIRONMENT} environment secrets 설정이 완료되었습니다!${NC}"

--- a/scripts/setup-ssh-key.sh
+++ b/scripts/setup-ssh-key.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+# ANSI 색상 코드
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+NC='\033[0m'
+
+# SSH 디렉토리 및 파일 확인
+echo "SSH 설정을 확인합니다..."
+
+# .ssh 디렉토리가 없으면 생성
+if [ ! -d ~/.ssh ]; then
+    echo ".ssh 디렉토리를 생성합니다..."
+    mkdir -p ~/.ssh
+    chmod 700 ~/.ssh
+fi
+
+# id_ed25519 파일이 이미 존재하는지 확인
+if [ -f ~/.ssh/id_ed25519 ]; then
+    echo "${YELLOW}SSH 키가 이미 존재합니다.${NC}"
+    echo "기존 키를 사용하시겠습니까? (y/n)"
+    read -r response
+    if [ "$response" = "y" ]; then
+        echo "${GREEN}기존 SSH 키를 사용합니다.${NC}"
+    else
+        echo "새로운 키로 대체하시겠습니까? 이 작업은 되돌릴 수 없습니다. (y/n)"
+        read -r replace
+        if [ "$replace" = "y" ]; then
+            echo "${RED}Warning: 필요한 경우 기존 키를 먼저 백업하는 것을 추천합니다.${NC}"
+            echo "계속하시겠습니까? (y/n)"
+            read -r confirm
+            if [ "$confirm" = "y" ]; then
+                echo "새로운 SSH 키를 생성합니다..."
+                echo "이메일 주소를 입력해주세요:"
+                read -r email
+                rm ~/.ssh/id_ed25519*
+                ssh-keygen -t ed25519 -b 4096 -C "$email"
+            else
+                echo "${RED}스크립트를 종료합니다.${NC}"
+                exit 1
+            fi
+        else
+            echo "${RED}스크립트를 종료합니다.${NC}"
+            exit 1
+        fi
+    fi
+else
+    # SSH 키 생성
+    echo "새로운 SSH 키를 생성합니다..."
+    echo "이메일 주소를 입력해주세요:"
+    read -r email
+    ssh-keygen -t ed25519 -b 4096 -C "$email"
+fi
+
+# authorized_keys 설정
+echo "authorized_keys 파일을 설정합니다..."
+cat ~/.ssh/id_ed25519.pub >> ~/.ssh/authorized_keys
+chmod 600 ~/.ssh/authorized_keys
+
+echo "${GREEN}SSH 키 설정이 완료되었습니다!${NC}"

--- a/src/main/java/com/moonbaar/domain/event/controller/EventController.java
+++ b/src/main/java/com/moonbaar/domain/event/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.moonbaar.domain.event.controller;
 
 import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.exeption.EventErrorCode;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +45,11 @@ public class EventController {
         } catch (DateTimeParseException e) {
             throw new BusinessException(EventErrorCode.INVALID_EVENT_PARAMS);
         }
+    }
+
+    @GetMapping("/{eventId}")
+    public EventDetailResponse getEventDetail(@PathVariable Long eventId) {
+        return eventService.getEventDetail(eventId);
     }
 
     private EventSearchRequest createSearchRequest(

--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -1,0 +1,26 @@
+package com.moonbaar.domain.event.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record EventDetailResponse(
+        Long id,
+        String title,
+        String category,
+        String district,
+        String place,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        boolean isFree,
+        String useFee,
+        String useTarget,
+        String player,
+        String program,
+        String etcDesc,
+        String mainImg,
+        String orgName,
+        String orgLink,
+        BigDecimal latitude,
+        BigDecimal longitude
+) {
+}

--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -1,7 +1,11 @@
 package com.moonbaar.domain.event.dto;
 
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.entity.CulturalEvent;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public record EventDetailResponse(
         Long id,
@@ -23,4 +27,37 @@ public record EventDetailResponse(
         BigDecimal latitude,
         BigDecimal longitude
 ) {
+
+    public static EventDetailResponse from(CulturalEvent event) {
+        String categoryName = Optional.ofNullable(event.getCategory())
+                .map(Category::getName)
+                .orElse(null);
+
+        String districtName = Optional.ofNullable(event.getDistrict())
+                .map(District::getName)
+                .orElse(null);
+
+        boolean isFreeEvent = "무료".equals(event.getIsFree());
+
+        return new EventDetailResponse(
+                event.getId(),
+                event.getTitle(),
+                categoryName,
+                districtName,
+                event.getPlace(),
+                event.getStartDate(),
+                event.getEndDate(),
+                isFreeEvent,
+                event.getUseFee(),
+                event.getUseTarget(),
+                event.getPlayer(),
+                event.getProgram(),
+                event.getEtcDesc(),
+                event.getMainImg(),
+                event.getOrgName(),
+                event.getOrgLink(),
+                event.getLatitude(),
+                event.getLongitude()
+        );
+    }
 }

--- a/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
@@ -1,7 +1,12 @@
 package com.moonbaar.domain.event.dto;
 
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.entity.CulturalEvent;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public record EventSummaryResponse(
         Long id,
@@ -17,4 +22,28 @@ public record EventSummaryResponse(
         BigDecimal longitude
 //        boolean isLiked
 ) {
+
+    public static EventSummaryResponse from(CulturalEvent event) {
+        boolean isFreeEvent = "무료".equals(event.getIsFree());
+
+        return new EventSummaryResponse(
+                event.getId(),
+                event.getTitle(),
+                Optional.ofNullable(event.getCategory()).map(Category::getName).orElse(null),
+                Optional.ofNullable(event.getDistrict()).map(District::getName).orElse(null),
+                event.getPlace(),
+                event.getStartDate(),
+                event.getEndDate(),
+                isFreeEvent,
+                event.getMainImg(),
+                event.getLatitude(),
+                event.getLongitude()
+        );
+    }
+
+    public static List<EventSummaryResponse> fromList(List<CulturalEvent> events) {
+        return events.stream()
+                .map(EventSummaryResponse::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/moonbaar/domain/event/entity/CulturalEvent.java
+++ b/src/main/java/com/moonbaar/domain/event/entity/CulturalEvent.java
@@ -53,16 +53,16 @@ public class CulturalEvent extends BaseEntityWithUpdate {
     @Column(name = "etc_desc", columnDefinition = "TEXT")
     private String etcDesc;
 
-    @Column(name = "org_link")
+    @Column(name = "org_link", columnDefinition = "TEXT")
     private String orgLink;
 
-    @Column(name = "main_img")
+    @Column(name = "main_img", length = 500)
     private String mainImg;
 
     @Column
     private LocalDate rgstdate;
 
-    @Column
+    @Column(length = 50)
     private String ticket;
 
     @Column(name = "start_date", nullable = false)
@@ -71,7 +71,7 @@ public class CulturalEvent extends BaseEntityWithUpdate {
     @Column(name = "end_date")
     private LocalDateTime endDate;
 
-    @Column
+    @Column(length = 100)
     private String themecode;
 
     @Column(precision = 10, scale = 7)
@@ -80,7 +80,7 @@ public class CulturalEvent extends BaseEntityWithUpdate {
     @Column(precision = 10, scale = 7)
     private BigDecimal longitude;
 
-    @Column(name = "is_free")
+    @Column(name = "is_free", length = 10)
     private String isFree;
 
     @Column(name = "hmpg_addr")

--- a/src/main/java/com/moonbaar/domain/event/exeption/EventNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/event/exeption/EventNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.event.exeption;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class EventNotFoundException extends BusinessException {
+
+    public EventNotFoundException() {
+        super(EventErrorCode.EVENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -2,10 +2,12 @@ package com.moonbaar.domain.event.service;
 
 import com.moonbaar.domain.category.entity.Category;
 import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.dto.EventSummaryResponse;
 import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.event.exeption.EventNotFoundException;
 import com.moonbaar.domain.event.repository.CulturalEventRepository;
 import com.moonbaar.domain.event.repository.EventSpecifications;
 import java.util.List;
@@ -99,5 +101,15 @@ public class EventService {
                 eventPage.getNumber() + 1,
                 eventResponses
         );
+    }
+
+    public EventDetailResponse getEventDetail(Long eventId) {
+        CulturalEvent event = findEventById(eventId);
+        return EventDetailResponse.from(event);
+    }
+
+    private CulturalEvent findEventById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(EventNotFoundException::new);
     }
 }

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -1,7 +1,5 @@
 package com.moonbaar.domain.event.service;
 
-import com.moonbaar.domain.category.entity.Category;
-import com.moonbaar.domain.district.entity.District;
 import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
@@ -11,7 +9,6 @@ import com.moonbaar.domain.event.exeption.EventNotFoundException;
 import com.moonbaar.domain.event.repository.CulturalEventRepository;
 import com.moonbaar.domain.event.repository.EventSpecifications;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -33,7 +30,7 @@ public class EventService {
         Pageable pageable = createPageableWithSort(request);
 
         Page<CulturalEvent> eventPage = eventRepository.findAll(spec, pageable);
-        List<EventSummaryResponse> eventResponses = mapToEventResponses(eventPage.getContent());
+        List<EventSummaryResponse> eventResponses = EventSummaryResponse.fromList(eventPage.getContent());
 
         return createEventListResponse(eventPage, eventResponses);
     }
@@ -68,30 +65,6 @@ public class EventService {
             return "id"; // 임시로 id로 정렬(인기도 정렬은 추후 방문수와 좋아요 수 기준으로 확장)
         }
         return "startDate"; // 기본값은 시작일
-    }
-
-    private List<EventSummaryResponse> mapToEventResponses(List<CulturalEvent> events) {
-        return events.stream()
-                .map(this::mapToEventResponse)
-                .toList();
-    }
-
-    private EventSummaryResponse mapToEventResponse(CulturalEvent event) {
-        boolean isFreeEvent = "무료".equals(event.getIsFree());
-
-        return new EventSummaryResponse(
-                event.getId(),
-                event.getTitle(),
-                Optional.ofNullable(event.getCategory()).map(Category::getName).orElse(null),
-                Optional.ofNullable(event.getDistrict()).map(District::getName).orElse(null),
-                event.getPlace(),
-                event.getStartDate(),
-                event.getEndDate(),
-                isFreeEvent,
-                event.getMainImg(),
-                event.getLatitude(),
-                event.getLongitude()
-        );
     }
 
     private EventListResponse createEventListResponse(Page<CulturalEvent> eventPage, List<EventSummaryResponse> eventResponses) {

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -1,5 +1,7 @@
 package com.moonbaar.domain.event.service;
 
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.dto.EventSummaryResponse;
@@ -68,19 +70,18 @@ public class EventService {
 
     private List<EventSummaryResponse> mapToEventResponses(List<CulturalEvent> events) {
         return events.stream()
-                .map(event -> mapToEventResponse(event))
+                .map(this::mapToEventResponse)
                 .toList();
     }
 
     private EventSummaryResponse mapToEventResponse(CulturalEvent event) {
-//        boolean isLiked = checkIfEventIsLiked(event.getId(), userId);
         boolean isFreeEvent = "무료".equals(event.getIsFree());
 
         return new EventSummaryResponse(
                 event.getId(),
                 event.getTitle(),
-                Optional.ofNullable(event.getCategory()).map(c -> c.getName()).orElse(null),
-                Optional.ofNullable(event.getDistrict()).map(d -> d.getName()).orElse(null),
+                Optional.ofNullable(event.getCategory()).map(Category::getName).orElse(null),
+                Optional.ofNullable(event.getDistrict()).map(District::getName).orElse(null),
                 event.getPlace(),
                 event.getStartDate(),
                 event.getEndDate(),
@@ -88,16 +89,8 @@ public class EventService {
                 event.getMainImg(),
                 event.getLatitude(),
                 event.getLongitude()
-//                isLiked
         );
     }
-
-//    private boolean checkIfEventIsLiked(Long eventId, Long userId) {
-//        if (userId == null) {
-//            return false;
-//        }
-//        return likedEventRepository.existsByEventIdAndUserId(eventId, userId);
-//    }
 
     private EventListResponse createEventListResponse(Page<CulturalEvent> eventPage, List<EventSummaryResponse> eventResponses) {
         return new EventListResponse(

--- a/src/test/java/com/moonbaar/common/config/SecurityTestConfig.java
+++ b/src/test/java/com/moonbaar/common/config/SecurityTestConfig.java
@@ -1,0 +1,20 @@
+package com.moonbaar.common.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class SecurityTestConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll());
+
+        return http.build();
+    }
+}

--- a/src/test/java/com/moonbaar/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/event/controller/EventControllerTest.java
@@ -1,0 +1,94 @@
+package com.moonbaar.domain.event.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.moonbaar.common.config.SecurityTestConfig;
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
+import com.moonbaar.domain.event.exeption.EventErrorCode;
+import com.moonbaar.domain.event.service.EventService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(EventController.class)
+@Import(SecurityTestConfig.class)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EventService eventService;
+
+    @Test
+    @DisplayName("행사 상세 정보를 조회한다")
+    void getEventDetail() throws Exception {
+        // given
+        Long eventId = 1L;
+        LocalDateTime startDate = LocalDateTime.now().plusDays(1);
+        LocalDateTime endDate = LocalDateTime.now().plusDays(3);
+
+        EventDetailResponse response = new EventDetailResponse(
+                eventId,
+                "서울시극단 [코믹]",
+                "연극",
+                "종로구",
+                "세종M씨어터",
+                startDate,
+                endDate,
+                false,
+                "30,000원 ~ 50,000원",
+                "전체 관람가",
+                "김문화, 이예술, 박공연",
+                "유쾌한 코미디 연극입니다.",
+                "서울시극단이 선보이는 유쾌한 코미디 연극입니다.",
+                "https://example.com/image1.jpg",
+                "세종문화회관",
+                "https://www.seoulevent.or.kr",
+                new BigDecimal("37.5725"),
+                new BigDecimal("126.9760")
+        );
+
+        when(eventService.getEventDetail(eventId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/events/{eventId}", eventId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(eventId.intValue()))
+                .andExpect(jsonPath("$.title").value("서울시극단 [코믹]"))
+                .andExpect(jsonPath("$.category").value("연극"))
+                .andExpect(jsonPath("$.district").value("종로구"))
+                .andExpect(jsonPath("$.place").value("세종M씨어터"))
+                .andExpect(jsonPath("$.isFree").value(false))
+                .andExpect(jsonPath("$.useFee").value("30,000원 ~ 50,000원"))
+                .andExpect(jsonPath("$.useTarget").value("전체 관람가"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 행사 ID로 조회 시 404 응답을 반환한다")
+    void getEventDetail_WithNonExistingId_ReturnsNotFound() throws Exception {
+        // given
+        Long nonExistingId = 999L;
+        when(eventService.getEventDetail(nonExistingId))
+                .thenThrow(new BusinessException(EventErrorCode.EVENT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/events/{eventId}", nonExistingId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(EventErrorCode.EVENT_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(EventErrorCode.EVENT_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
@@ -1,0 +1,103 @@
+package com.moonbaar.domain.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.event.exeption.EventErrorCode;
+import com.moonbaar.domain.event.repository.CulturalEventRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock
+    private CulturalEventRepository eventRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private CulturalEvent sampleEvent;
+
+    @BeforeEach
+    void setUp() {
+        Category category = Category.builder()
+                .name("연극")
+                .build();
+        ReflectionTestUtils.setField(category, "id", 1L);
+
+        District district = District.builder()
+                .name("종로구")
+                .build();
+        ReflectionTestUtils.setField(district, "id", 1L);
+
+        sampleEvent = CulturalEvent.builder()
+                .title("서울시극단 [코믹]")
+                .place("세종M씨어터")
+                .orgName("세종문화회관")
+                .useTarget("전체 관람가")
+                .useFee("30,000원 ~ 50,000원")
+                .player("김문화, 이예술, 박공연")
+                .program("유쾌한 코미디 연극입니다. 일상 속 소소한 웃음을 선사합니다.")
+                .etcDesc("서울시극단이 선보이는 유쾌한 코미디 연극입니다.")
+                .orgLink("https://www.sejongpac.or.kr")
+                .mainImg("https://example.com/image1.jpg")
+                .startDate(LocalDateTime.now().plusDays(1))
+                .endDate(LocalDateTime.now().plusDays(3))
+                .isFree("유료")
+                .latitude(new BigDecimal("37.5725"))
+                .longitude(new BigDecimal("126.9760"))
+                .category(category)
+                .district(district)
+                .build();
+        ReflectionTestUtils.setField(sampleEvent, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("행사 ID로 상세 정보를 조회할 수 있다")
+    void getEventDetail_ShouldReturnEventDetail() {
+        // given
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(sampleEvent));
+
+        // when
+        EventDetailResponse response = eventService.getEventDetail(1L);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("서울시극단 [코믹]");
+        assertThat(response.category()).isEqualTo("연극");
+        assertThat(response.district()).isEqualTo("종로구");
+        assertThat(response.isFree()).isFalse();
+        assertThat(response.useFee()).isEqualTo("30,000원 ~ 50,000원");
+        assertThat(response.place()).isEqualTo("세종M씨어터");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 행사 ID로 조회 시 예외가 발생한다")
+    void getEventDetail_WithNonExistingId_ShouldThrowException() {
+        // given
+        Long nonExistingId = 999L;
+        when(eventRepository.findById(nonExistingId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventDetail(nonExistingId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EventErrorCode.EVENT_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 이슈
- #10 

## 설명
서울시 문화행사 데이터를 기반으로 특정 행사의 상세 정보를 조회할 수 있는 API를 구현했습니다. 사용자가 문화 행사에 대한 자세한 정보를 확인할 수 있는 기능입니다.

## 주요 변경사항
- 행사 상세 정보 응답 DTO(EventDetailResponse) 생성
- 행사 상세 정보 조회 서비스 로직 구현
- 행사 상세 정보 조회 컨트롤러 엔드포인트 구현
- 서비스 및 컨트롤러에 대한 단위 테스트 추가

## API 명세
- 엔드포인트: `GET /api/events/{eventId}`
- 응답 형식: 행사 상세 정보를 포함한 JSON 객체
- 오류 코드: 404 (행사 정보 없음)

## 사용자 관련 기능
사용자 관련 기능(좋아요, 방문 인증 등)은 사용자 모듈 구현 후 추후 확장 예정입니다.