### PR TITLE
feat: 행사 상세 조회 api 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,9 +2,9 @@ name: Deploy to Development Server
 
 on:
   push:
-    branches: [test-server]
+    branches: [develop]
   pull_request:
-    branches: [test-server]
+    branches: [develop]
 
 jobs:
   build-and-deploy:

--- a/src/main/java/com/moonbaar/domain/event/controller/EventController.java
+++ b/src/main/java/com/moonbaar/domain/event/controller/EventController.java
@@ -1,6 +1,7 @@
 package com.moonbaar.domain.event.controller;
 
 import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.exeption.EventErrorCode;
@@ -9,6 +10,7 @@ import java.time.LocalDate;
 import java.time.format.DateTimeParseException;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -43,6 +45,11 @@ public class EventController {
         } catch (DateTimeParseException e) {
             throw new BusinessException(EventErrorCode.INVALID_EVENT_PARAMS);
         }
+    }
+
+    @GetMapping("/{eventId}")
+    public EventDetailResponse getEventDetail(@PathVariable Long eventId) {
+        return eventService.getEventDetail(eventId);
     }
 
     private EventSearchRequest createSearchRequest(

--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -1,0 +1,26 @@
+package com.moonbaar.domain.event.dto;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record EventDetailResponse(
+        Long id,
+        String title,
+        String category,
+        String district,
+        String place,
+        LocalDateTime startDate,
+        LocalDateTime endDate,
+        boolean isFree,
+        String useFee,
+        String useTarget,
+        String player,
+        String program,
+        String etcDesc,
+        String mainImg,
+        String orgName,
+        String orgLink,
+        BigDecimal latitude,
+        BigDecimal longitude
+) {
+}

--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -1,7 +1,11 @@
 package com.moonbaar.domain.event.dto;
 
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.entity.CulturalEvent;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.Optional;
 
 public record EventDetailResponse(
         Long id,
@@ -23,4 +27,37 @@ public record EventDetailResponse(
         BigDecimal latitude,
         BigDecimal longitude
 ) {
+
+    public static EventDetailResponse from(CulturalEvent event) {
+        String categoryName = Optional.ofNullable(event.getCategory())
+                .map(Category::getName)
+                .orElse(null);
+
+        String districtName = Optional.ofNullable(event.getDistrict())
+                .map(District::getName)
+                .orElse(null);
+
+        boolean isFreeEvent = "무료".equals(event.getIsFree());
+
+        return new EventDetailResponse(
+                event.getId(),
+                event.getTitle(),
+                categoryName,
+                districtName,
+                event.getPlace(),
+                event.getStartDate(),
+                event.getEndDate(),
+                isFreeEvent,
+                event.getUseFee(),
+                event.getUseTarget(),
+                event.getPlayer(),
+                event.getProgram(),
+                event.getEtcDesc(),
+                event.getMainImg(),
+                event.getOrgName(),
+                event.getOrgLink(),
+                event.getLatitude(),
+                event.getLongitude()
+        );
+    }
 }

--- a/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
@@ -1,7 +1,12 @@
 package com.moonbaar.domain.event.dto;
 
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.entity.CulturalEvent;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
 
 public record EventSummaryResponse(
         Long id,
@@ -17,4 +22,28 @@ public record EventSummaryResponse(
         BigDecimal longitude
 //        boolean isLiked
 ) {
+
+    public static EventSummaryResponse from(CulturalEvent event) {
+        boolean isFreeEvent = "무료".equals(event.getIsFree());
+
+        return new EventSummaryResponse(
+                event.getId(),
+                event.getTitle(),
+                Optional.ofNullable(event.getCategory()).map(Category::getName).orElse(null),
+                Optional.ofNullable(event.getDistrict()).map(District::getName).orElse(null),
+                event.getPlace(),
+                event.getStartDate(),
+                event.getEndDate(),
+                isFreeEvent,
+                event.getMainImg(),
+                event.getLatitude(),
+                event.getLongitude()
+        );
+    }
+
+    public static List<EventSummaryResponse> fromList(List<CulturalEvent> events) {
+        return events.stream()
+                .map(EventSummaryResponse::from)
+                .toList();
+    }
 }

--- a/src/main/java/com/moonbaar/domain/event/exeption/EventNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/event/exeption/EventNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.event.exeption;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class EventNotFoundException extends BusinessException {
+
+    public EventNotFoundException() {
+        super(EventErrorCode.EVENT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -2,10 +2,12 @@ package com.moonbaar.domain.event.service;
 
 import com.moonbaar.domain.category.entity.Category;
 import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.dto.EventSummaryResponse;
 import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.event.exeption.EventNotFoundException;
 import com.moonbaar.domain.event.repository.CulturalEventRepository;
 import com.moonbaar.domain.event.repository.EventSpecifications;
 import java.util.List;
@@ -99,5 +101,15 @@ public class EventService {
                 eventPage.getNumber() + 1,
                 eventResponses
         );
+    }
+
+    public EventDetailResponse getEventDetail(Long eventId) {
+        CulturalEvent event = findEventById(eventId);
+        return EventDetailResponse.from(event);
+    }
+
+    private CulturalEvent findEventById(Long eventId) {
+        return eventRepository.findById(eventId)
+                .orElseThrow(EventNotFoundException::new);
     }
 }

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -1,7 +1,5 @@
 package com.moonbaar.domain.event.service;
 
-import com.moonbaar.domain.category.entity.Category;
-import com.moonbaar.domain.district.entity.District;
 import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
@@ -11,7 +9,6 @@ import com.moonbaar.domain.event.exeption.EventNotFoundException;
 import com.moonbaar.domain.event.repository.CulturalEventRepository;
 import com.moonbaar.domain.event.repository.EventSpecifications;
 import java.util.List;
-import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
@@ -33,7 +30,7 @@ public class EventService {
         Pageable pageable = createPageableWithSort(request);
 
         Page<CulturalEvent> eventPage = eventRepository.findAll(spec, pageable);
-        List<EventSummaryResponse> eventResponses = mapToEventResponses(eventPage.getContent());
+        List<EventSummaryResponse> eventResponses = EventSummaryResponse.fromList(eventPage.getContent());
 
         return createEventListResponse(eventPage, eventResponses);
     }
@@ -68,30 +65,6 @@ public class EventService {
             return "id"; // 임시로 id로 정렬(인기도 정렬은 추후 방문수와 좋아요 수 기준으로 확장)
         }
         return "startDate"; // 기본값은 시작일
-    }
-
-    private List<EventSummaryResponse> mapToEventResponses(List<CulturalEvent> events) {
-        return events.stream()
-                .map(this::mapToEventResponse)
-                .toList();
-    }
-
-    private EventSummaryResponse mapToEventResponse(CulturalEvent event) {
-        boolean isFreeEvent = "무료".equals(event.getIsFree());
-
-        return new EventSummaryResponse(
-                event.getId(),
-                event.getTitle(),
-                Optional.ofNullable(event.getCategory()).map(Category::getName).orElse(null),
-                Optional.ofNullable(event.getDistrict()).map(District::getName).orElse(null),
-                event.getPlace(),
-                event.getStartDate(),
-                event.getEndDate(),
-                isFreeEvent,
-                event.getMainImg(),
-                event.getLatitude(),
-                event.getLongitude()
-        );
     }
 
     private EventListResponse createEventListResponse(Page<CulturalEvent> eventPage, List<EventSummaryResponse> eventResponses) {

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -1,5 +1,7 @@
 package com.moonbaar.domain.event.service;
 
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.dto.EventSummaryResponse;
@@ -68,19 +70,18 @@ public class EventService {
 
     private List<EventSummaryResponse> mapToEventResponses(List<CulturalEvent> events) {
         return events.stream()
-                .map(event -> mapToEventResponse(event))
+                .map(this::mapToEventResponse)
                 .toList();
     }
 
     private EventSummaryResponse mapToEventResponse(CulturalEvent event) {
-//        boolean isLiked = checkIfEventIsLiked(event.getId(), userId);
         boolean isFreeEvent = "무료".equals(event.getIsFree());
 
         return new EventSummaryResponse(
                 event.getId(),
                 event.getTitle(),
-                Optional.ofNullable(event.getCategory()).map(c -> c.getName()).orElse(null),
-                Optional.ofNullable(event.getDistrict()).map(d -> d.getName()).orElse(null),
+                Optional.ofNullable(event.getCategory()).map(Category::getName).orElse(null),
+                Optional.ofNullable(event.getDistrict()).map(District::getName).orElse(null),
                 event.getPlace(),
                 event.getStartDate(),
                 event.getEndDate(),
@@ -88,16 +89,8 @@ public class EventService {
                 event.getMainImg(),
                 event.getLatitude(),
                 event.getLongitude()
-//                isLiked
         );
     }
-
-//    private boolean checkIfEventIsLiked(Long eventId, Long userId) {
-//        if (userId == null) {
-//            return false;
-//        }
-//        return likedEventRepository.existsByEventIdAndUserId(eventId, userId);
-//    }
 
     private EventListResponse createEventListResponse(Page<CulturalEvent> eventPage, List<EventSummaryResponse> eventResponses) {
         return new EventListResponse(

--- a/src/test/java/com/moonbaar/common/config/SecurityTestConfig.java
+++ b/src/test/java/com/moonbaar/common/config/SecurityTestConfig.java
@@ -1,0 +1,20 @@
+package com.moonbaar.common.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.SecurityFilterChain;
+
+@TestConfiguration
+public class SecurityTestConfig {
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers("/**").permitAll());
+
+        return http.build();
+    }
+}

--- a/src/test/java/com/moonbaar/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/event/controller/EventControllerTest.java
@@ -1,0 +1,94 @@
+package com.moonbaar.domain.event.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.moonbaar.common.config.SecurityTestConfig;
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
+import com.moonbaar.domain.event.exeption.EventErrorCode;
+import com.moonbaar.domain.event.service.EventService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(EventController.class)
+@Import(SecurityTestConfig.class)
+class EventControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private EventService eventService;
+
+    @Test
+    @DisplayName("행사 상세 정보를 조회한다")
+    void getEventDetail() throws Exception {
+        // given
+        Long eventId = 1L;
+        LocalDateTime startDate = LocalDateTime.now().plusDays(1);
+        LocalDateTime endDate = LocalDateTime.now().plusDays(3);
+
+        EventDetailResponse response = new EventDetailResponse(
+                eventId,
+                "서울시극단 [코믹]",
+                "연극",
+                "종로구",
+                "세종M씨어터",
+                startDate,
+                endDate,
+                false,
+                "30,000원 ~ 50,000원",
+                "전체 관람가",
+                "김문화, 이예술, 박공연",
+                "유쾌한 코미디 연극입니다.",
+                "서울시극단이 선보이는 유쾌한 코미디 연극입니다.",
+                "https://example.com/image1.jpg",
+                "세종문화회관",
+                "https://www.seoulevent.or.kr",
+                new BigDecimal("37.5725"),
+                new BigDecimal("126.9760")
+        );
+
+        when(eventService.getEventDetail(eventId)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(get("/events/{eventId}", eventId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(eventId.intValue()))
+                .andExpect(jsonPath("$.title").value("서울시극단 [코믹]"))
+                .andExpect(jsonPath("$.category").value("연극"))
+                .andExpect(jsonPath("$.district").value("종로구"))
+                .andExpect(jsonPath("$.place").value("세종M씨어터"))
+                .andExpect(jsonPath("$.isFree").value(false))
+                .andExpect(jsonPath("$.useFee").value("30,000원 ~ 50,000원"))
+                .andExpect(jsonPath("$.useTarget").value("전체 관람가"));
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 행사 ID로 조회 시 404 응답을 반환한다")
+    void getEventDetail_WithNonExistingId_ReturnsNotFound() throws Exception {
+        // given
+        Long nonExistingId = 999L;
+        when(eventService.getEventDetail(nonExistingId))
+                .thenThrow(new BusinessException(EventErrorCode.EVENT_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/events/{eventId}", nonExistingId)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound())
+                .andExpect(jsonPath("$.code").value(EventErrorCode.EVENT_NOT_FOUND.getCode()))
+                .andExpect(jsonPath("$.message").value(EventErrorCode.EVENT_NOT_FOUND.getMessage()));
+    }
+}

--- a/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
@@ -1,0 +1,103 @@
+package com.moonbaar.domain.event.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.when;
+
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.category.entity.Category;
+import com.moonbaar.domain.district.entity.District;
+import com.moonbaar.domain.event.dto.EventDetailResponse;
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.event.exeption.EventErrorCode;
+import com.moonbaar.domain.event.repository.CulturalEventRepository;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@ExtendWith(MockitoExtension.class)
+class EventServiceTest {
+
+    @Mock
+    private CulturalEventRepository eventRepository;
+
+    @InjectMocks
+    private EventService eventService;
+
+    private CulturalEvent sampleEvent;
+
+    @BeforeEach
+    void setUp() {
+        Category category = Category.builder()
+                .name("연극")
+                .build();
+        ReflectionTestUtils.setField(category, "id", 1L);
+
+        District district = District.builder()
+                .name("종로구")
+                .build();
+        ReflectionTestUtils.setField(district, "id", 1L);
+
+        sampleEvent = CulturalEvent.builder()
+                .title("서울시극단 [코믹]")
+                .place("세종M씨어터")
+                .orgName("세종문화회관")
+                .useTarget("전체 관람가")
+                .useFee("30,000원 ~ 50,000원")
+                .player("김문화, 이예술, 박공연")
+                .program("유쾌한 코미디 연극입니다. 일상 속 소소한 웃음을 선사합니다.")
+                .etcDesc("서울시극단이 선보이는 유쾌한 코미디 연극입니다.")
+                .orgLink("https://www.sejongpac.or.kr")
+                .mainImg("https://example.com/image1.jpg")
+                .startDate(LocalDateTime.now().plusDays(1))
+                .endDate(LocalDateTime.now().plusDays(3))
+                .isFree("유료")
+                .latitude(new BigDecimal("37.5725"))
+                .longitude(new BigDecimal("126.9760"))
+                .category(category)
+                .district(district)
+                .build();
+        ReflectionTestUtils.setField(sampleEvent, "id", 1L);
+    }
+
+    @Test
+    @DisplayName("행사 ID로 상세 정보를 조회할 수 있다")
+    void getEventDetail_ShouldReturnEventDetail() {
+        // given
+        when(eventRepository.findById(1L)).thenReturn(Optional.of(sampleEvent));
+
+        // when
+        EventDetailResponse response = eventService.getEventDetail(1L);
+
+        // then
+        assertThat(response).isNotNull();
+        assertThat(response.id()).isEqualTo(1L);
+        assertThat(response.title()).isEqualTo("서울시극단 [코믹]");
+        assertThat(response.category()).isEqualTo("연극");
+        assertThat(response.district()).isEqualTo("종로구");
+        assertThat(response.isFree()).isFalse();
+        assertThat(response.useFee()).isEqualTo("30,000원 ~ 50,000원");
+        assertThat(response.place()).isEqualTo("세종M씨어터");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 행사 ID로 조회 시 예외가 발생한다")
+    void getEventDetail_WithNonExistingId_ShouldThrowException() {
+        // given
+        Long nonExistingId = 999L;
+        when(eventRepository.findById(nonExistingId)).thenReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> eventService.getEventDetail(nonExistingId))
+                .isInstanceOf(BusinessException.class)
+                .hasFieldOrPropertyWithValue("errorCode", EventErrorCode.EVENT_NOT_FOUND);
+    }
+}


### PR DESCRIPTION
## 이슈
- #10 

## 설명
서울시 문화행사 데이터를 기반으로 특정 행사의 상세 정보를 조회할 수 있는 API를 구현했습니다. 사용자가 문화 행사에 대한 자세한 정보를 확인할 수 있는 기능입니다.

## 주요 변경사항
- 행사 상세 정보 응답 DTO(EventDetailResponse) 생성
- 행사 상세 정보 조회 서비스 로직 구현
- 행사 상세 정보 조회 컨트롤러 엔드포인트 구현
- 서비스 및 컨트롤러에 대한 단위 테스트 추가

## API 명세
- 엔드포인트: `GET /api/events/{eventId}`
- 응답 형식: 행사 상세 정보를 포함한 JSON 객체
- 오류 코드: 404 (행사 정보 없음)

## 사용자 관련 기능
사용자 관련 기능(좋아요, 방문 인증 등)은 사용자 모듈 구현 후 추후 확장 예정입니다.