### PR TITLE
feat: 카테고리, 행정구역 목록 조회 api 구현 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,8 +1,6 @@
 name: Deploy to Development Server
 
 on:
-  push:
-    branches: [develop]
   pull_request:
     branches: [develop]
 

--- a/src/main/java/com/moonbaar/domain/category/controller/CategoryController.java
+++ b/src/main/java/com/moonbaar/domain/category/controller/CategoryController.java
@@ -1,0 +1,28 @@
+package com.moonbaar.domain.category.controller;
+
+import com.moonbaar.domain.category.dto.CategoryListResponse;
+import com.moonbaar.domain.category.dto.CategoryResponse;
+import com.moonbaar.domain.category.service.CategoryService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/categories")
+@RequiredArgsConstructor
+public class CategoryController {
+
+    private final CategoryService categoryService;
+
+    @GetMapping
+    public CategoryListResponse getCategories() {
+        return categoryService.getAllCategories();
+    }
+
+    @GetMapping("/by-name/{name}")
+    public CategoryResponse getCategoryByName(@PathVariable String name) {
+        return categoryService.getCategoryByName(name);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/category/dto/CategoryListResponse.java
+++ b/src/main/java/com/moonbaar/domain/category/dto/CategoryListResponse.java
@@ -1,0 +1,16 @@
+package com.moonbaar.domain.category.dto;
+
+import com.moonbaar.domain.category.entity.Category;
+import java.util.List;
+
+public record CategoryListResponse(
+        List<CategoryResponse> categories
+) {
+    public static CategoryListResponse from(List<Category> categories) {
+        List<CategoryResponse> responses = categories.stream()
+                .map(CategoryResponse::from)
+                .toList();
+
+        return new CategoryListResponse(responses);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/category/dto/CategoryResponse.java
+++ b/src/main/java/com/moonbaar/domain/category/dto/CategoryResponse.java
@@ -1,0 +1,15 @@
+package com.moonbaar.domain.category.dto;
+
+import com.moonbaar.domain.category.entity.Category;
+
+public record CategoryResponse(
+        Long id,
+        String name
+) {
+
+    public static CategoryResponse from(Category category) {
+        return new CategoryResponse(
+                category.getId(),
+                category.getName());
+    }
+}

--- a/src/main/java/com/moonbaar/domain/category/exception/CategoryErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/category/exception/CategoryErrorCode.java
@@ -1,0 +1,17 @@
+package com.moonbaar.domain.category.exception;
+
+import com.moonbaar.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum CategoryErrorCode implements ErrorCode {
+
+    CATEGORY_NOT_FOUND("C001", "요청한 카테고리를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/domain/category/exception/CategoryNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/category/exception/CategoryNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.category.exception;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class CategoryNotFoundException extends BusinessException {
+
+    public CategoryNotFoundException() {
+        super(CategoryErrorCode.CATEGORY_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/category/repository/CategoryRepository.java
+++ b/src/main/java/com/moonbaar/domain/category/repository/CategoryRepository.java
@@ -1,0 +1,14 @@
+package com.moonbaar.domain.category.repository;
+
+import com.moonbaar.domain.category.entity.Category;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CategoryRepository extends JpaRepository<Category, Long> {
+
+    @Query("SELECT c FROM Category c WHERE c.name = :name")
+    Optional<Category> findByName(String name);
+}

--- a/src/main/java/com/moonbaar/domain/category/service/CategoryService.java
+++ b/src/main/java/com/moonbaar/domain/category/service/CategoryService.java
@@ -1,0 +1,27 @@
+package com.moonbaar.domain.category.service;
+
+import com.moonbaar.domain.category.dto.CategoryListResponse;
+import com.moonbaar.domain.category.dto.CategoryResponse;
+import com.moonbaar.domain.category.exception.CategoryNotFoundException;
+import com.moonbaar.domain.category.repository.CategoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CategoryService {
+
+    private final CategoryRepository categoryRepository;
+
+    public CategoryListResponse getAllCategories() {
+        return CategoryListResponse.from(categoryRepository.findAll());
+    }
+
+    public CategoryResponse getCategoryByName(String name) {
+        return categoryRepository.findByName(name)
+                .map(CategoryResponse::from)
+                .orElseThrow(CategoryNotFoundException::new);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/district/controller/DistrictController.java
+++ b/src/main/java/com/moonbaar/domain/district/controller/DistrictController.java
@@ -1,0 +1,28 @@
+package com.moonbaar.domain.district.controller;
+
+import com.moonbaar.domain.district.dto.DistrictListResponse;
+import com.moonbaar.domain.district.dto.DistrictResponse;
+import com.moonbaar.domain.district.service.DistrictService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/districts")
+@RequiredArgsConstructor
+public class DistrictController {
+
+    private final DistrictService districtService;
+
+    @GetMapping
+    public DistrictListResponse getDistricts() {
+        return districtService.getAllDistricts();
+    }
+
+    @GetMapping("/by-name/{name}")
+    public DistrictResponse getDistrictByName(@PathVariable String name) {
+        return districtService.getDistrictByName(name);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/district/dto/DistrictListResponse.java
+++ b/src/main/java/com/moonbaar/domain/district/dto/DistrictListResponse.java
@@ -1,0 +1,16 @@
+package com.moonbaar.domain.district.dto;
+
+import com.moonbaar.domain.district.entity.District;
+import java.util.List;
+
+public record DistrictListResponse(
+        List<DistrictResponse> districts
+) {
+    public static DistrictListResponse from(List<District> districts) {
+        List<DistrictResponse> responses = districts.stream()
+                .map(DistrictResponse::from)
+                .toList();
+
+        return new DistrictListResponse(responses);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/district/dto/DistrictResponse.java
+++ b/src/main/java/com/moonbaar/domain/district/dto/DistrictResponse.java
@@ -1,0 +1,15 @@
+package com.moonbaar.domain.district.dto;
+
+import com.moonbaar.domain.district.entity.District;
+
+public record DistrictResponse(
+        Long id,
+        String name
+) {
+
+    public static DistrictResponse from(District district) {
+        return new DistrictResponse(
+                district.getId(),
+                district.getName());
+    }
+}

--- a/src/main/java/com/moonbaar/domain/district/exception/DistrictErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/district/exception/DistrictErrorCode.java
@@ -1,0 +1,17 @@
+package com.moonbaar.domain.district.exception;
+
+import com.moonbaar.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum DistrictErrorCode implements ErrorCode {
+
+    DISTRICT_NOT_FOUND("D001", "요청한 행정구역을 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/domain/district/exception/DistrictNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/district/exception/DistrictNotFoundException.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.district.exception;
+
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class DistrictNotFoundException extends BusinessException {
+
+    public DistrictNotFoundException() {
+        super(DistrictErrorCode.DISTRICT_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/district/repository/DistrictRepository.java
+++ b/src/main/java/com/moonbaar/domain/district/repository/DistrictRepository.java
@@ -1,0 +1,14 @@
+package com.moonbaar.domain.district.repository;
+
+import com.moonbaar.domain.district.entity.District;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface DistrictRepository extends JpaRepository<District, Long> {
+
+    @Query("SELECT d FROM District d WHERE d.name = :name")
+    Optional<District> findByName(String name);
+}

--- a/src/main/java/com/moonbaar/domain/district/service/DistrictService.java
+++ b/src/main/java/com/moonbaar/domain/district/service/DistrictService.java
@@ -1,0 +1,29 @@
+package com.moonbaar.domain.district.service;
+
+import com.moonbaar.domain.category.dto.CategoryResponse;
+import com.moonbaar.domain.category.exception.CategoryNotFoundException;
+import com.moonbaar.domain.district.dto.DistrictListResponse;
+import com.moonbaar.domain.district.dto.DistrictResponse;
+import com.moonbaar.domain.district.exception.DistrictNotFoundException;
+import com.moonbaar.domain.district.repository.DistrictRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class DistrictService {
+
+    private final DistrictRepository districtRepository;
+
+    public DistrictListResponse getAllDistricts() {
+        return DistrictListResponse.from(districtRepository.findAll());
+    }
+
+    public DistrictResponse getDistrictByName(String name) {
+        return districtRepository.findByName(name)
+                .map(DistrictResponse::from)
+                .orElseThrow(DistrictNotFoundException::new);
+    }
+}

--- a/src/test/java/com/moonbaar/domain/category/controller/CategoryControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/category/controller/CategoryControllerTest.java
@@ -1,0 +1,75 @@
+package com.moonbaar.domain.category.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.moonbaar.common.config.SecurityTestConfig;
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.category.dto.CategoryListResponse;
+import com.moonbaar.domain.category.dto.CategoryResponse;
+import com.moonbaar.domain.category.exception.CategoryErrorCode;
+import com.moonbaar.domain.category.service.CategoryService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(CategoryController.class)
+@Import(SecurityTestConfig.class)
+public class CategoryControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private CategoryService categoryService;
+
+    @Test
+    void getCategories_shouldReturnCategoryList() throws Exception {
+        // given
+        CategoryResponse category1 = new CategoryResponse(1L, "연극");
+        CategoryResponse category2 = new CategoryResponse(2L, "전시/미술");
+        CategoryListResponse responseDTO = new CategoryListResponse(List.of(category1, category2));
+
+        when(categoryService.getAllCategories()).thenReturn(responseDTO);
+
+        // when & then
+        mockMvc.perform(get("/categories")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void getCategoryByExactName_shouldReturnSingleCategory() throws Exception {
+        // given
+        CategoryResponse category = new CategoryResponse(1L, "연극");
+
+        when(categoryService.getCategoryByName("연극")).thenReturn(category);
+
+        // when & then
+        mockMvc.perform(get("/categories/by-name/연극")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void getCategoryByExactName_shouldReturn404WhenNotFound() throws Exception {
+        // given
+        when(categoryService.getCategoryByName(anyString()))
+                .thenThrow(new BusinessException(CategoryErrorCode.CATEGORY_NOT_FOUND));
+
+        // when & then
+        mockMvc.perform(get("/categories/by-name/존재하지않는카테고리")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+}

--- a/src/test/java/com/moonbaar/domain/district/controller/DistrictControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/district/controller/DistrictControllerTest.java
@@ -1,0 +1,75 @@
+package com.moonbaar.domain.district.controller;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.moonbaar.common.config.SecurityTestConfig;
+import com.moonbaar.common.exception.BusinessException;
+import com.moonbaar.domain.district.dto.DistrictListResponse;
+import com.moonbaar.domain.district.dto.DistrictResponse;
+import com.moonbaar.domain.district.exception.DistrictErrorCode;
+import com.moonbaar.domain.district.service.DistrictService;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(DistrictController.class)
+@Import(SecurityTestConfig.class)
+public class DistrictControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private DistrictService districtService;
+
+    @Test
+    void getDistricts_shouldReturnDistrictList() throws Exception {
+        // Given
+        DistrictResponse district1 = new DistrictResponse(1L, "강남구");
+        DistrictResponse district2 = new DistrictResponse(2L, "종로구");
+        DistrictListResponse responseDTO = new DistrictListResponse(List.of(district1, district2));
+
+        when(districtService.getAllDistricts()).thenReturn(responseDTO);
+
+        // When & Then
+        mockMvc.perform(get("/districts")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void getDistrictByExactName_shouldReturnSingleDistrict() throws Exception {
+        // Given
+        DistrictResponse district = new DistrictResponse(1L, "강남구");
+
+        when(districtService.getDistrictByName("강남구")).thenReturn(district);
+
+        // When & Then
+        mockMvc.perform(get("/districts/by-name/강남구")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON));
+    }
+
+    @Test
+    void getDistrictByExactName_shouldReturn404WhenNotFound() throws Exception {
+        // Given
+        when(districtService.getDistrictByName(anyString()))
+                .thenThrow(new BusinessException(DistrictErrorCode.DISTRICT_NOT_FOUND));
+
+        // When & Then
+        mockMvc.perform(get("/districts/by-name/존재하지않는행정구역")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
+    }
+}


### PR DESCRIPTION
## 관련 이슈
- #14 

## 설명
문화발자국 서비스에서 필요한 카테고리와 행정구역 정보를 조회할 수 있는 API를 구현했습니다.
카테고리와 행정구역의 ID를 반환하고 해당 ID를 통해 프론트엔드에서 행사목록 필터링을 할 수 있도록 했습니다.

## 주요 변경사항

- 카테고리/행정구역 목록 조회 API 구현 (GET /categories, GET /districts)
- 이름으로 단일 카테고리/행정구역 조회 API 구현 (GET /categories/by-name/{name}, GET /districts/by-name/{name})
- 정적 팩토리 메서드 패턴을 적용한 DTO 구현
- Repository, Service, Controller 계층 구현
- Given-When-Then 패턴을 적용한 단위 테스트 작성

## API 명세

- 전체 목록 조회

  - 엔드포인트: GET /api/categories, GET /api/districts
  - 응답 형식: 카테고리/행정구역 목록을 포함한 JSON 객체

- 이름으로 단일 조회
  - 엔드포인트: GET /api/categories/by-name/{name}, GET /api/districts/by-name/{name}
  - 응답 형식: 단일 카테고리/행정구역 정보를 포함한 JSON 객체
  - 오류 코드: 404 (해당 이름의 카테고리/행정구역이 없음)

## API 응답 예시

```json
// GET /api/categories
{
  "categories": [
    { "id": 1, "name": "연극" },
    { "id": 2, "name": "전시/미술" },
    { "id": 3, "name": "콘서트" }
  ]
}

// GET /api/categories/by-name/연극
{
  "id": 1,
  "name": "연극"
}
```