### PR TITLE
feat: 행사 좋아요 API 구현

### DIFF
--- a/src/main/java/com/moonbaar/MoonbaarApplication.java
+++ b/src/main/java/com/moonbaar/MoonbaarApplication.java
@@ -2,8 +2,10 @@ package com.moonbaar;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
 @SpringBootApplication
+@EnableJpaAuditing
 public class MoonbaarApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/moonbaar/domain/like/controller/LikeController.java
+++ b/src/main/java/com/moonbaar/domain/like/controller/LikeController.java
@@ -5,6 +5,7 @@ import com.moonbaar.domain.like.service.LikeService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -15,14 +16,19 @@ import org.springframework.web.bind.annotation.RequestMapping;
 public class LikeController {
 
     // 임시 유저 아이디
-    private Long userId = 1L;
+    private Long MOCK_USER_ID = 1L;
 
     private final LikeService likeService;
 
     @PostMapping("/{eventId}/like")
     public ResponseEntity<LikeResponse> likeEvent(@PathVariable Long eventId) {
-        LikeResponse response = likeService.likeEvent(eventId, userId);
+        LikeResponse response = likeService.likeEvent(eventId, MOCK_USER_ID);
         return ResponseEntity.ok(response);
     }
 
+    @DeleteMapping("/{eventId}/like")
+    public ResponseEntity<LikeResponse> unlikeEvent(@PathVariable Long eventId) {
+        LikeResponse response = likeService.unlikeEvent(MOCK_USER_ID, eventId);
+        return ResponseEntity.ok(response);
+    }
 }

--- a/src/main/java/com/moonbaar/domain/like/controller/LikeController.java
+++ b/src/main/java/com/moonbaar/domain/like/controller/LikeController.java
@@ -1,0 +1,28 @@
+package com.moonbaar.domain.like.controller;
+
+import com.moonbaar.domain.like.dto.LikeResponse;
+import com.moonbaar.domain.like.service.LikeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+@Controller
+@RequestMapping("/events")
+@RequiredArgsConstructor
+public class LikeController {
+
+    // 임시 유저 아이디
+    private Long userId = 1L;
+
+    private final LikeService likeService;
+
+    @PostMapping("/{eventId}/like")
+    public ResponseEntity<LikeResponse> likeEvent(@PathVariable Long eventId) {
+        LikeResponse response = likeService.likeEvent(eventId, userId);
+        return ResponseEntity.ok(response);
+    }
+
+}

--- a/src/main/java/com/moonbaar/domain/like/dto/LikeResponse.java
+++ b/src/main/java/com/moonbaar/domain/like/dto/LikeResponse.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.like.dto;
+
+public record LikeResponse(
+        Long eventId,
+        boolean isLiked
+) {
+
+    public static LikeResponse of(Long eventId, boolean isLiked) {
+        return new LikeResponse(eventId, isLiked);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
+++ b/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
@@ -1,0 +1,32 @@
+package com.moonbaar.domain.like.entity;
+
+import com.moonbaar.common.entity.BaseEntity;
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.user.entity.User;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "liked_events")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class LikedEvent extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private CulturalEvent event;
+}

--- a/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
+++ b/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
@@ -8,6 +8,7 @@ import jakarta.persistence.FetchType;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -15,8 +16,12 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 @Entity
-@Table(name = "liked_events")
-@Getter
+@Table(
+        name = "liked_events",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"user_id", "event_id"})
+        }
+)@Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder

--- a/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
+++ b/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
@@ -34,4 +34,8 @@ public class LikedEvent extends BaseEntity {
     @ManyToOne(fetch = FetchType.LAZY)
     @JoinColumn(name = "event_id", nullable = false)
     private CulturalEvent event;
+
+    public static LikedEvent of(CulturalEvent event, User user) {
+        return new LikedEvent(user, event);
+    }
 }

--- a/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
+++ b/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
@@ -35,7 +35,7 @@ public class LikedEvent extends BaseEntity {
     @JoinColumn(name = "event_id", nullable = false)
     private CulturalEvent event;
 
-    public static LikedEvent of(CulturalEvent event, User user) {
+    public static LikedEvent of(User user, CulturalEvent event) {
         return new LikedEvent(user, event);
     }
 }

--- a/src/main/java/com/moonbaar/domain/like/exception/AlreadyLikedEventException.java
+++ b/src/main/java/com/moonbaar/domain/like/exception/AlreadyLikedEventException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.like.exception;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class AlreadyLikedEventException extends BusinessException {
+
+    public AlreadyLikedEventException() {
+        super(LikeErrorCode.ALREADY_LIKED_EVENT);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/like/exception/LikeErrorCode.java
@@ -1,0 +1,18 @@
+package com.moonbaar.domain.like.exception;
+
+import com.moonbaar.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum LikeErrorCode implements ErrorCode {
+
+    ALREADY_LIKED_EVENT("L001", "이미 좋아요한 행사입니다.", HttpStatus.CONFLICT),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/domain/like/exception/LikeErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/like/exception/LikeErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum LikeErrorCode implements ErrorCode {
 
     ALREADY_LIKED_EVENT("L001", "이미 좋아요한 행사입니다.", HttpStatus.CONFLICT),
+    LIKE_NOT_FOUND("L002", "좋아요 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
     ;
 
     private final String code;

--- a/src/main/java/com/moonbaar/domain/like/exception/LikeNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/like/exception/LikeNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.like.exception;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class LikeNotFoundException extends BusinessException {
+
+    public LikeNotFoundException() {
+        super(LikeErrorCode.LIKE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/like/repository/LikedEventRepository.java
+++ b/src/main/java/com/moonbaar/domain/like/repository/LikedEventRepository.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.like.repository;
+
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.like.entity.LikedEvent;
+import com.moonbaar.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LikedEventRepository extends JpaRepository<LikedEvent, Long> {
+
+  boolean existsByUserAndEvent(User user, CulturalEvent event);
+}

--- a/src/main/java/com/moonbaar/domain/like/repository/LikedEventRepository.java
+++ b/src/main/java/com/moonbaar/domain/like/repository/LikedEventRepository.java
@@ -3,9 +3,12 @@ package com.moonbaar.domain.like.repository;
 import com.moonbaar.domain.event.entity.CulturalEvent;
 import com.moonbaar.domain.like.entity.LikedEvent;
 import com.moonbaar.domain.user.entity.User;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LikedEventRepository extends JpaRepository<LikedEvent, Long> {
 
   boolean existsByUserAndEvent(User user, CulturalEvent event);
+
+  Optional<LikedEvent> findByUserAndEvent(User user, CulturalEvent event);
 }

--- a/src/main/java/com/moonbaar/domain/like/service/LikeService.java
+++ b/src/main/java/com/moonbaar/domain/like/service/LikeService.java
@@ -6,6 +6,7 @@ import com.moonbaar.domain.event.repository.CulturalEventRepository;
 import com.moonbaar.domain.like.dto.LikeResponse;
 import com.moonbaar.domain.like.entity.LikedEvent;
 import com.moonbaar.domain.like.exception.AlreadyLikedEventException;
+import com.moonbaar.domain.like.exception.LikeNotFoundException;
 import com.moonbaar.domain.like.repository.LikedEventRepository;
 import com.moonbaar.domain.user.entity.User;
 import com.moonbaar.domain.user.exception.UserNotFoundException;
@@ -35,6 +36,17 @@ public class LikeService {
         return LikeResponse.of(eventId, true);
     }
 
+    @Transactional
+    public LikeResponse unlikeEvent(Long userId, Long eventId) {
+        User user = findUser(userId);
+        CulturalEvent event = findEvent(eventId);
+
+        LikedEvent likedEvent = findLikedEvent(user, event);
+        likedEventRepository.delete(likedEvent);
+
+        return LikeResponse.of(eventId, false);
+    }
+
     private User findUser(Long userId) {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
@@ -49,5 +61,10 @@ public class LikeService {
         if (likedEventRepository.existsByUserAndEvent(user, event)) {
             throw new AlreadyLikedEventException();
         }
+    }
+
+    private LikedEvent findLikedEvent(User user, CulturalEvent event) {
+        return likedEventRepository.findByUserAndEvent(user, event)
+                .orElseThrow(LikeNotFoundException::new);
     }
 }

--- a/src/main/java/com/moonbaar/domain/like/service/LikeService.java
+++ b/src/main/java/com/moonbaar/domain/like/service/LikeService.java
@@ -30,7 +30,7 @@ public class LikeService {
 
         checkNotAlreadyLiked(user, event);
 
-        LikedEvent likedEvent = LikedEvent.of(event, user);
+        LikedEvent likedEvent = LikedEvent.of(user, event);
         likedEventRepository.save(likedEvent);
 
         return LikeResponse.of(eventId, true);

--- a/src/main/java/com/moonbaar/domain/like/service/LikeService.java
+++ b/src/main/java/com/moonbaar/domain/like/service/LikeService.java
@@ -1,0 +1,53 @@
+package com.moonbaar.domain.like.service;
+
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.event.exeption.EventNotFoundException;
+import com.moonbaar.domain.event.repository.CulturalEventRepository;
+import com.moonbaar.domain.like.dto.LikeResponse;
+import com.moonbaar.domain.like.entity.LikedEvent;
+import com.moonbaar.domain.like.exception.AlreadyLikedEventException;
+import com.moonbaar.domain.like.repository.LikedEventRepository;
+import com.moonbaar.domain.user.entity.User;
+import com.moonbaar.domain.user.exception.UserNotFoundException;
+import com.moonbaar.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class LikeService {
+
+    private final UserRepository userRepository;
+    private final CulturalEventRepository culturalEventRepository;
+    private final LikedEventRepository likedEventRepository;
+
+    @Transactional
+    public LikeResponse likeEvent(Long userId, Long eventId) {
+        User user = findUser(userId);
+        CulturalEvent event = findEvent(eventId);
+
+        checkNotAlreadyLiked(user, event);
+
+        LikedEvent likedEvent = LikedEvent.of(event, user);
+        likedEventRepository.save(likedEvent);
+
+        return LikeResponse.of(eventId, true);
+    }
+
+    private User findUser(Long userId) {
+        return userRepository.findById(userId)
+                .orElseThrow(UserNotFoundException::new);
+    }
+
+    private CulturalEvent findEvent(Long eventId) {
+        return culturalEventRepository.findById(eventId)
+                .orElseThrow(EventNotFoundException::new);
+    }
+
+    private void checkNotAlreadyLiked(User user, CulturalEvent event) {
+        if (likedEventRepository.existsByUserAndEvent(user, event)) {
+            throw new AlreadyLikedEventException();
+        }
+    }
+}

--- a/src/main/java/com/moonbaar/domain/user/entity/User.java
+++ b/src/main/java/com/moonbaar/domain/user/entity/User.java
@@ -1,0 +1,37 @@
+package com.moonbaar.domain.user.entity;
+
+import com.moonbaar.common.entity.BaseEntityWithUpdate;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import jakarta.validation.constraints.NotNull;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+
+@Entity
+@Table(name="users")
+@Getter
+@NoArgsConstructor(access= AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class User extends BaseEntityWithUpdate {
+
+    @NotNull
+    @Column(name = "oauth_id", nullable = false, unique = true)
+    private String oauthId;
+
+    @NotNull
+    @Column(name = "oauth_provider", nullable = false)
+    private String oauthProvider;
+
+    @NotNull
+    @Column(nullable = false)
+    private String nickname;
+
+    @Column(name = "profile_image_url")
+    private String profileImageUrl;
+}

--- a/src/main/java/com/moonbaar/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/user/exception/UserErrorCode.java
@@ -1,0 +1,18 @@
+package com.moonbaar.domain.user.exception;
+
+import com.moonbaar.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum UserErrorCode implements ErrorCode {
+
+    USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ;
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/domain/user/exception/UserNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/user/exception/UserNotFoundException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.user.exception;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class UserNotFoundException extends BusinessException {
+
+    public UserNotFoundException() {
+        super(UserErrorCode.USER_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
@@ -1,0 +1,7 @@
+package com.moonbaar.domain.user.repository;
+
+import com.moonbaar.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UserRepository extends JpaRepository<User, Long> {
+}

--- a/src/test/java/com/moonbaar/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/like/controller/LikeControllerTest.java
@@ -1,6 +1,7 @@
 package com.moonbaar.domain.like.controller;
 
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -8,6 +9,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.moonbaar.common.config.SecurityTestConfig;
 import com.moonbaar.domain.like.dto.LikeResponse;
 import com.moonbaar.domain.like.exception.AlreadyLikedEventException;
+import com.moonbaar.domain.like.exception.LikeNotFoundException;
 import com.moonbaar.domain.like.service.LikeService;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
@@ -56,5 +58,32 @@ public class LikeControllerTest {
         mockMvc.perform(post("/events/{eventId}/like", EVENT_ID)
                         .contentType(MediaType.APPLICATION_JSON))
                 .andExpect(status().isConflict());
+    }
+
+    @Test
+    @DisplayName("좋아요 취소 성공")
+    void unlikeEvent_Success() throws Exception {
+        // given
+        LikeResponse response = new LikeResponse(EVENT_ID, false);
+        when(likeService.unlikeEvent(MOCK_USER_ID, EVENT_ID)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(delete("/events/{eventId}/like", EVENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(EVENT_ID))
+                .andExpect(jsonPath("$.isLiked").value(false));
+    }
+
+    @Test
+    @DisplayName("좋아요하지 않은 행사 취소 시 404 응답")
+    void unlikeEvent_NotLiked() throws Exception {
+        // given
+        when(likeService.unlikeEvent(MOCK_USER_ID, EVENT_ID)).thenThrow(new LikeNotFoundException());
+
+        // when & then
+        mockMvc.perform(delete("/events/{eventId}/like", EVENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isNotFound());
     }
 }

--- a/src/test/java/com/moonbaar/domain/like/controller/LikeControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/like/controller/LikeControllerTest.java
@@ -1,0 +1,60 @@
+package com.moonbaar.domain.like.controller;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.moonbaar.common.config.SecurityTestConfig;
+import com.moonbaar.domain.like.dto.LikeResponse;
+import com.moonbaar.domain.like.exception.AlreadyLikedEventException;
+import com.moonbaar.domain.like.service.LikeService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(LikeController.class)
+@Import(SecurityTestConfig.class)
+public class LikeControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockitoBean
+    private LikeService likeService;
+
+    private final Long MOCK_USER_ID = 1L;
+    private final Long EVENT_ID = 1L;
+
+    @Test
+    @DisplayName("행사 좋아요 성공")
+    void likeEvent_Success() throws Exception {
+        // given
+        LikeResponse response = LikeResponse.of(EVENT_ID, true);
+        when(likeService.likeEvent(MOCK_USER_ID, EVENT_ID)).thenReturn(response);
+
+        // when & then
+        mockMvc.perform(post("/events/{eventId}/like", EVENT_ID)
+                    .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.eventId").value(EVENT_ID))
+                .andExpect(jsonPath("$.isLiked").value(true));
+    }
+
+    @Test
+    @DisplayName("이미 좋아요한 행사를 다시 좋아요 시 409 응답")
+    void likeEvent_AlreadyLiked() throws Exception {
+        // given
+        when(likeService.likeEvent(MOCK_USER_ID, EVENT_ID)).thenThrow(new AlreadyLikedEventException());
+
+        // when & then
+        mockMvc.perform(post("/events/{eventId}/like", EVENT_ID)
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isConflict());
+    }
+}


### PR DESCRIPTION
## 이슈
- #22 

## 변경사항
- 좋아요 엔티티(`LikedEvent`) 및 제약조건 구현
- 좋아요 서비스 및 컨트롤러 구현
- 관련 예외 처리 및 응답 DTO 구현
- 이벤트 상세 조회 시 좋아요 상태 포함
- 단위 테스트 작성 
- 테스트용 Mock 사용자 데이터 SQL 구현
- JPA Auditing 설정 추가 (`@EnableJpaAuditing`)

## 세부설명
사용자가 행사에 좋아요를 표시할 수 있는 API를 구현했습니다. (`POST /events/{eventId}/like`)
좋아요 취소 API를 구현했습니다. (`DELETE /events/{eventId}/like`)
이에 따라 이벤트 상세 정보 조회 시 기존에는 false로 고정하여 돌려주었던 좋아요 여부를 실제 db에서 조회해 응답합니다.

중복 좋아요 방지를 위한 제약 조건 및 예외 처리를 구현했습니다.

현재 OAuth 인증 없이 목 사용자(ID: 1)로 사용자가 고정되게 해두었습니다. 현재 리퀘스트의 결과는 ID 1 유저의 좋아요 정보로 들어가게 됩니다.

좋아요 기능 구현 중 `@EnableJpaAuditing` 어노테이션 누락으로 인해 BaseEntity의 createdAt 필드가 null로 저장되는 문제가 발생했으나, 애플리케이션 클래스에 해당 어노테이션을 추가하여 해결했습니다.