### PR TITLE
feat: OAuth2 로그인 기능 구현

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,11 +27,9 @@ jobs:
           restore-keys: ${{ runner.os }}-gradle-
 
       # 서브모듈 설정
-      - name: Setup submodule
+      - name: Update submodule
         run: |
-          cd src/main/resources/config
-          git pull
-          cd ../../../../
+          git submodule update --init --remote --merge
 
       # GitHub Container Registry 로그인
       - name: Login to GitHub Container Registry

--- a/build.gradle
+++ b/build.gradle
@@ -28,9 +28,12 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-oauth2-client'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
+	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 
 	compileOnly 'org.projectlombok:lombok'
 	runtimeOnly 'com.mysql:mysql-connector-j'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.11.5'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.11.5'
 	annotationProcessor 'org.projectlombok:lombok'
 
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.moonbaar.common.config;
 
+import com.moonbaar.common.filter.JwtAuthenticationFilter;
 import com.moonbaar.common.oauth.handler.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
@@ -10,6 +11,7 @@ import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
@@ -23,6 +25,7 @@ public class SecurityConfig {
 
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -33,6 +36,7 @@ public class SecurityConfig {
                         .requestMatchers("/login", "/oauth2/**", "/events/**", "/categories/**", "/districts/**", "/users/**").permitAll()  // 공개 API 경로
                         .anyRequest().authenticated()  // 나머지 경로는 인증 필요
                 )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
                 // OAuth2 로그인 설정
                 .oauth2Login(oauth -> oauth

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -39,6 +39,8 @@ public class SecurityConfig {
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
 
                 // OAuth2 로그인 설정
+                .formLogin(form -> form.disable())
+                .logout(logout -> logout.disable())
                 .oauth2Login(oauth -> oauth
                         // 로그인 후 사용자 정보 가져올 때 사용할 서비스 지정
                         .userInfoEndpoint(userInfo -> userInfo .userService(customOAuth2UserService))

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -1,5 +1,6 @@
 package com.moonbaar.common.config;
 
+import com.moonbaar.common.oauth.handler.OAuth2SuccessHandler;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -21,6 +22,7 @@ import java.util.Arrays;
 public class SecurityConfig {
 
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService;
+    private final OAuth2SuccessHandler oAuth2SuccessHandler;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -36,7 +38,7 @@ public class SecurityConfig {
                 .oauth2Login(oauth -> oauth
                         // 로그인 후 사용자 정보 가져올 때 사용할 서비스 지정
                         .userInfoEndpoint(userInfo -> userInfo .userService(customOAuth2UserService))
-                        .defaultSuccessUrl("/", true)
+                        .successHandler(oAuth2SuccessHandler)
                 );
 
         return http.build();

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -1,18 +1,26 @@
 package com.moonbaar.common.config;
 
-import java.util.Arrays;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
+import java.util.Arrays;
+
 @Configuration
 @EnableWebSecurity
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -20,8 +28,15 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/events/**", "/categories/**", "/districts/**", "/users/**").permitAll()  // 공개 API 경로
+                        .requestMatchers("/login", "/oauth2/**", "/events/**", "/categories/**", "/districts/**", "/users/**").permitAll()  // 공개 API 경로
                         .anyRequest().authenticated()  // 나머지 경로는 인증 필요
+                )
+
+                // OAuth2 로그인 설정
+                .oauth2Login(oauth -> oauth
+                        // 로그인 후 사용자 정보 가져올 때 사용할 서비스 지정
+                        .userInfoEndpoint(userInfo -> userInfo .userService(customOAuth2UserService))
+                        .defaultSuccessUrl("/", true)
                 );
 
         return http.build();

--- a/src/main/java/com/moonbaar/common/dto/OAuthAttributes.java
+++ b/src/main/java/com/moonbaar/common/dto/OAuthAttributes.java
@@ -1,0 +1,68 @@
+package com.moonbaar.common.dto;
+
+import com.moonbaar.domain.user.entity.User;
+import lombok.extern.slf4j.Slf4j;
+
+import java.util.Map;
+
+/**
+ * OAuth2 인증을 통해 받아온 사용자 정보를 애플리케이션에서 사용할 형태로 변환하여 담는 DTO 클래스
+ * Provider마다 다른 응답 포맷에 맞게 파싱하여 같은 형태로 통일한다.
+ *
+ * @param attributes            사용자 정보
+ * @param userNameAttributeName 사용자 고유 ID key값
+ * @param oauthId               사용자 고유 ID
+ * @param oauthProvider         OAuth 로그인을 제공한 서비스
+ * @param nickname              사용자 이름
+ * @param profileImageUrl       사용자 프로필 이미지
+ */
+@Slf4j
+public record OAuthAttributes(
+        Map<String, Object> attributes,
+        String userNameAttributeName,
+        String oauthId,
+        String oauthProvider,
+        String nickname,
+        String profileImageUrl
+) {
+
+    public static OAuthAttributes of(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        return switch (registrationId) {
+            case "naver" -> ofNaver(registrationId, "id", (Map<String, Object>) attributes.get("response"));
+            default -> ofKakao(registrationId, userNameAttributeName, attributes);
+        };
+    }
+
+    private static OAuthAttributes ofNaver(String registrationId, String userNameAttributeName, Map<String, Object> response) {
+        return new OAuthAttributes(
+                response,
+                userNameAttributeName,
+                (String) response.get(userNameAttributeName),
+                registrationId,
+                (String) response.get("name"),
+                (String) response.get("profile_image")
+        );
+    }
+
+    private static OAuthAttributes ofKakao(String registrationId, String userNameAttributeName, Map<String, Object> attributes) {
+        Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
+        Map<String, Object> profile = (Map<String, Object>) kakaoAccount.get("profile");
+        return new OAuthAttributes(
+                attributes,
+                userNameAttributeName,
+                String.valueOf(attributes.get(userNameAttributeName)),
+                registrationId,
+                (String) profile.get("nickname"),
+                (String) profile.get("profile_image_url")
+        );
+    }
+
+    public User toEntity() {
+        return User.builder()
+                .oauthId(oauthId)
+                .oauthProvider(oauthProvider)
+                .nickname(nickname)
+                .profileImageUrl(profileImageUrl)
+                .build();
+    }
+}

--- a/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
@@ -1,0 +1,33 @@
+package com.moonbaar.common.filter;
+
+import com.moonbaar.common.oauth.TokenBlackList;
+import com.moonbaar.common.utils.JwtUtils;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@Component
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtUtils jwtUtils;
+    private final TokenBlackList tokenBlackList;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
+                                    FilterChain filterChain) throws ServletException, IOException {
+        String accessToken = jwtUtils.resolveToken(request, "accessToken");
+        if (accessToken == null || !jwtUtils.isValid(accessToken) || tokenBlackList.contains(accessToken)) {
+            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+            return;
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
@@ -30,4 +30,15 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
         filterChain.doFilter(request, response);
     }
+
+    @Override
+    protected boolean shouldNotFilter(HttpServletRequest request) throws ServletException {
+        String path = request.getRequestURI();
+        return path.startsWith("/api/login") ||
+                path.startsWith("/api/oauth2") ||
+                path.startsWith("/api/events") ||
+                path.startsWith("/api/categories") ||
+                path.startsWith("/api/districts") ||
+                path.startsWith("/api/users");
+    }
 }

--- a/src/main/java/com/moonbaar/common/oauth/CustomOAuth2User.java
+++ b/src/main/java/com/moonbaar/common/oauth/CustomOAuth2User.java
@@ -1,0 +1,34 @@
+package com.moonbaar.common.oauth;
+
+import java.util.Collection;
+import java.util.Map;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+
+@Getter
+@AllArgsConstructor
+public class CustomOAuth2User implements OAuth2User {
+
+    private final Long userId;
+    private final Collection<? extends GrantedAuthority> authorities;
+    private final Map<String, Object> attributes;
+    private final String nameAttributeKey;
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attributes;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getName() {
+        return attributes.get(nameAttributeKey).toString();
+    }
+
+}

--- a/src/main/java/com/moonbaar/common/oauth/TokenBlackList.java
+++ b/src/main/java/com/moonbaar/common/oauth/TokenBlackList.java
@@ -1,0 +1,26 @@
+package com.moonbaar.common.oauth;
+
+import java.time.LocalDateTime;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import org.springframework.stereotype.Component;
+
+@Component
+public class TokenBlackList {
+
+    // key: accessToken, value: 만료시간
+    private final Map<String, LocalDateTime> blacklist = new ConcurrentHashMap<>();
+
+    public void add(String token, LocalDateTime expiresAt) {
+        blacklist.put(token, expiresAt);
+    }
+
+    public boolean contains(String token) {
+        return blacklist.containsKey(token);
+    }
+
+    public void removeExpiredTokens() {
+        blacklist.entrySet().removeIf(entry -> entry.getValue().isBefore(LocalDateTime.now()));
+    }
+
+}

--- a/src/main/java/com/moonbaar/common/oauth/dto/OAuthAttributes.java
+++ b/src/main/java/com/moonbaar/common/oauth/dto/OAuthAttributes.java
@@ -1,4 +1,4 @@
-package com.moonbaar.common.dto;
+package com.moonbaar.common.oauth.dto;
 
 import com.moonbaar.domain.user.entity.User;
 import lombok.extern.slf4j.Slf4j;

--- a/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
@@ -1,0 +1,56 @@
+package com.moonbaar.common.oauth.handler;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moonbaar.common.oauth.CustomOAuth2User;
+import com.moonbaar.common.utils.JwtUtils;
+import com.moonbaar.domain.user.entity.User;
+import com.moonbaar.domain.user.repository.UserRepository;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import java.io.IOException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.web.authentication.AuthenticationSuccessHandler;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
+
+    private final JwtUtils jwtUtils;
+    private final UserRepository userRepository;
+    private final ObjectMapper objectMapper;
+
+    @Value("${frontend.redirect-url}")
+    private String redirectUrl;
+
+    @Override
+    public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
+        Authentication authentication) throws IOException, ServletException {
+
+        // 사용자 정보 가져오기
+        CustomOAuth2User  oAuth2User = (CustomOAuth2User) authentication.getPrincipal();
+        Long userId = oAuth2User.getUserId();
+        User user = userRepository.findById(userId)
+            .orElseThrow(()-> new IllegalArgumentException("로그인된 사용자가 DB에 존재하지 않습니다."));
+
+        // JWT 발급
+        String accessToken = jwtUtils.generateAccessToken(user.getId(), "ROLE_USER");
+
+        Cookie cookie = new Cookie("accessToken", accessToken);
+        cookie.setHttpOnly(true);
+        cookie.setSecure(true);
+        cookie.setPath("/");
+        cookie.setMaxAge(60 * 30); // 30분
+        cookie.setAttribute("SameSite", "Lax");
+
+        response.addCookie(cookie);
+
+        response.sendRedirect(redirectUrl + "/login-success");
+    }
+}

--- a/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
@@ -27,6 +27,12 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     @Value("${frontend.redirect-url}")
     private String redirectUrl;
 
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpirationMs;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpirationMs;
+
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
         Authentication authentication) throws IOException {
@@ -49,14 +55,14 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         accessCookie.setHttpOnly(true);
         accessCookie.setSecure(true);
         accessCookie.setPath("/");
-        accessCookie.setMaxAge(60 * 30); // 30분
+        accessCookie.setMaxAge((int) (accessTokenExpirationMs / 1000));
         accessCookie.setAttribute("SameSite", "Lax");
 
         Cookie refreshCookie = new Cookie("refreshToken", refreshToken);
         refreshCookie.setHttpOnly(true);
         refreshCookie.setSecure(true);
         refreshCookie.setPath("/");
-        refreshCookie.setMaxAge(60 * 60 * 24);  // 1일
+        refreshCookie.setMaxAge((int) (refreshTokenExpirationMs / 1000));
         refreshCookie.setAttribute("SameSite", "Lax");
 
         response.addCookie(accessCookie);

--- a/src/main/java/com/moonbaar/common/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/moonbaar/common/oauth/service/CustomOAuth2UserService.java
@@ -1,13 +1,14 @@
-package com.moonbaar.common.service;
+package com.moonbaar.common.oauth.service;
 
-import com.moonbaar.common.dto.OAuthAttributes;
+import com.moonbaar.common.oauth.CustomOAuth2User;
+import com.moonbaar.common.oauth.dto.OAuthAttributes;
+import com.moonbaar.domain.user.entity.User;
 import com.moonbaar.domain.user.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
 import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
-import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 
@@ -33,10 +34,11 @@ public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequ
         OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
 
         // 회원가입 또는 프로필 업데이트 처리
-        userService.saveOrUpdate(attributes, registrationId);
+        User user = userService.saveOrUpdate(attributes, registrationId);
 
         // Spring Security가 인식할 사용자 객체 반환
-        return new DefaultOAuth2User(
+        return new CustomOAuth2User(
+                user.getId(),
                 Collections.singleton(() -> "ROLE_USER"),
                 attributes.attributes(),
                 attributes.userNameAttributeName()

--- a/src/main/java/com/moonbaar/common/service/CustomOAuth2UserService.java
+++ b/src/main/java/com/moonbaar/common/service/CustomOAuth2UserService.java
@@ -1,0 +1,46 @@
+package com.moonbaar.common.service;
+
+import com.moonbaar.common.dto.OAuthAttributes;
+import com.moonbaar.domain.user.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.client.userinfo.OAuth2UserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.user.DefaultOAuth2User;
+import org.springframework.security.oauth2.core.user.OAuth2User;
+import org.springframework.stereotype.Service;
+
+import java.util.Collections;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOAuth2UserService implements OAuth2UserService<OAuth2UserRequest, OAuth2User> {
+
+    private final UserService userService;
+
+    @Override
+    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
+        OAuth2User oAuth2User = new DefaultOAuth2UserService().loadUser(userRequest);
+
+        // OAuth2 Provider 이름 ex) kakao, naver
+        String registrationId = userRequest.getClientRegistration().getRegistrationId();
+        // 사용자의 고유 ID의 Key 값
+        String userNameAttributeName = userRequest.getClientRegistration()
+                .getProviderDetails().getUserInfoEndpoint().getUserNameAttributeName();
+
+        // attributes 표준 매핑
+        OAuthAttributes attributes = OAuthAttributes.of(registrationId, userNameAttributeName, oAuth2User.getAttributes());
+
+        // 회원가입 또는 프로필 업데이트 처리
+        userService.saveOrUpdate(attributes, registrationId);
+
+        // Spring Security가 인식할 사용자 객체 반환
+        return new DefaultOAuth2User(
+                Collections.singleton(() -> "ROLE_USER"),
+                attributes.attributes(),
+                attributes.userNameAttributeName()
+        );
+    }
+
+}

--- a/src/main/java/com/moonbaar/common/utils/JwtUtils.java
+++ b/src/main/java/com/moonbaar/common/utils/JwtUtils.java
@@ -29,8 +29,10 @@ public class JwtUtils {
     private String secretKey;
     private Key key;
 
-    private final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 30; // 30분
-    private final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24; // 1일
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
 
     @PostConstruct
     public void init() {
@@ -40,7 +42,7 @@ public class JwtUtils {
     // Access Token 생성
     public String generateAccessToken(Long userId) {
         Date now = new Date();
-        Date expiry = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION);
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
         return Jwts.builder()
             .setSubject(String.valueOf(userId))
             .setIssuedAt(now)
@@ -52,7 +54,7 @@ public class JwtUtils {
     // Refresh Token 생성
     public String generateRefreshToken(Long userId) {
         Date now = new Date();
-        Date expiry = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION);
+        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
         return Jwts.builder()
             .setSubject(String.valueOf(userId))
             .setIssuedAt(now)

--- a/src/main/java/com/moonbaar/common/utils/JwtUtils.java
+++ b/src/main/java/com/moonbaar/common/utils/JwtUtils.java
@@ -1,0 +1,89 @@
+package com.moonbaar.common.utils;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.ExpiredJwtException;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.MalformedJwtException;
+import io.jsonwebtoken.SignatureAlgorithm;
+import io.jsonwebtoken.UnsupportedJwtException;
+import io.jsonwebtoken.security.Keys;
+import io.jsonwebtoken.security.SignatureException;
+import jakarta.annotation.PostConstruct;
+import java.security.Key;
+import java.util.Date;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+@Slf4j
+@Component
+public class JwtUtils {
+
+    @Value("${jwt.secret-key}")
+    private String secretKey;
+    private Key key;
+
+    private final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 30; // 30분
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secretKey.getBytes());
+    }
+
+    // Access Token 생성
+    public String generateAccessToken(Long userId, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION);
+        return Jwts.builder()
+            .setSubject(String.valueOf(userId))
+            .claim("role", role)
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    // token에서 userId 추출
+    public Long getUserId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    // token에서 role 추출
+    public String getRole(String token) {
+        return parseClaims(token).get("role", String.class);
+    }
+
+    // 토큰 유효성 검사
+    public boolean isValid(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (SecurityException | SignatureException e) {
+            log.error("서명 검증 실패 : {}", e.getMessage());
+        } catch (MalformedJwtException e) {
+            log.error("손상된 토큰 : {}", e.getMessage());
+        } catch (ExpiredJwtException e) {
+            log.error("만료된 토큰 : {}", e.getMessage());
+        } catch (UnsupportedJwtException e) {
+            log.error("지원되지 않는 JWT : {}", e.getMessage());
+        } catch (IllegalArgumentException e) {
+            log.error("빈 토큰 혹은 잘못된 값 : {}", e.getMessage());
+        } catch (JwtException e) {
+            log.error("기타 JWT 오류 : {}", e.getMessage());
+        } catch (Exception e) {
+            log.error("예상치 못한 예외 : {}", e.getMessage());
+        }
+        return false;
+    }
+
+    // Claims 파싱
+    private Claims parseClaims(String token) {
+        return Jwts.parserBuilder()
+            .setSigningKey(key)
+            .build()
+            .parseClaimsJws(token)
+            .getBody();
+    }
+
+}

--- a/src/main/java/com/moonbaar/common/utils/JwtUtils.java
+++ b/src/main/java/com/moonbaar/common/utils/JwtUtils.java
@@ -25,6 +25,7 @@ public class JwtUtils {
     private Key key;
 
     private final long ACCESS_TOKEN_EXPIRATION = 1000L * 60 * 30; // 30분
+    private final long REFRESH_TOKEN_EXPIRATION = 1000L * 60 * 60 * 24; // 1일
 
     @PostConstruct
     public void init() {
@@ -32,12 +33,23 @@ public class JwtUtils {
     }
 
     // Access Token 생성
-    public String generateAccessToken(Long userId, String role) {
+    public String generateAccessToken(Long userId) {
         Date now = new Date();
         Date expiry = new Date(now.getTime() + ACCESS_TOKEN_EXPIRATION);
         return Jwts.builder()
             .setSubject(String.valueOf(userId))
-            .claim("role", role)
+            .setIssuedAt(now)
+            .setExpiration(expiry)
+            .signWith(key, SignatureAlgorithm.HS256)
+            .compact();
+    }
+
+    // Refresh Token 생성
+    public String generateRefreshToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + REFRESH_TOKEN_EXPIRATION);
+        return Jwts.builder()
+            .setSubject(String.valueOf(userId))
             .setIssuedAt(now)
             .setExpiration(expiry)
             .signWith(key, SignatureAlgorithm.HS256)
@@ -47,11 +59,6 @@ public class JwtUtils {
     // token에서 userId 추출
     public Long getUserId(String token) {
         return Long.valueOf(parseClaims(token).getSubject());
-    }
-
-    // token에서 role 추출
-    public String getRole(String token) {
-        return parseClaims(token).get("role", String.class);
     }
 
     // 토큰 유효성 검사

--- a/src/main/java/com/moonbaar/common/utils/JwtUtils.java
+++ b/src/main/java/com/moonbaar/common/utils/JwtUtils.java
@@ -10,7 +10,12 @@ import io.jsonwebtoken.UnsupportedJwtException;
 import io.jsonwebtoken.security.Keys;
 import io.jsonwebtoken.security.SignatureException;
 import jakarta.annotation.PostConstruct;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import java.security.Key;
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZoneId;
 import java.util.Date;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
@@ -56,9 +61,28 @@ public class JwtUtils {
             .compact();
     }
 
+    // 요청에서 토큰 추출
+    public String resolveToken(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals(name)) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
+
     // token에서 userId 추출
     public Long getUserId(String token) {
         return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    // 토큰 유효시간 추출
+    public LocalDateTime getExpiration(String token) {
+        Claims claims = parseClaims(token);
+        Date expiration = claims.getExpiration();
+        Instant instant = expiration.toInstant();
+        return LocalDateTime.ofInstant(instant, ZoneId.systemDefault());
     }
 
     // 토큰 유효성 검사

--- a/src/main/java/com/moonbaar/domain/user/controller/UserController.java
+++ b/src/main/java/com/moonbaar/domain/user/controller/UserController.java
@@ -34,6 +34,11 @@ public class UserController {
         return ResponseEntity.ok("Access Token 재발급 완료");
     }
 
+    @PostMapping("/logout")
+    public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
+        userService.logout(request, response);
+        return ResponseEntity.ok().build();
+    }
     @GetMapping("/me/likes")
     public ResponseEntity<LikedEventListResponse> getLikedEvents(
             @ModelAttribute @Valid LikedEventListRequest request) {

--- a/src/main/java/com/moonbaar/domain/user/controller/UserController.java
+++ b/src/main/java/com/moonbaar/domain/user/controller/UserController.java
@@ -1,5 +1,8 @@
 package com.moonbaar.domain.user.controller;
 
+import com.moonbaar.domain.user.service.UserService;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import com.moonbaar.domain.like.dto.LikedEventListRequest;
 import com.moonbaar.domain.like.dto.LikedEventListResponse;
 import com.moonbaar.domain.like.service.LikeService;
@@ -9,6 +12,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,6 +26,13 @@ public class UserController {
     private Long MOCK_USER_ID = 1L;
 
     private final LikeService likeService;
+    private final UserService userService;
+
+    @PostMapping("/refresh")
+    public ResponseEntity<?> refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        userService.refreshAccessToken(request, response);
+        return ResponseEntity.ok("Access Token 재발급 완료");
+    }
 
     @GetMapping("/me/likes")
     public ResponseEntity<LikedEventListResponse> getLikedEvents(

--- a/src/main/java/com/moonbaar/domain/user/entity/User.java
+++ b/src/main/java/com/moonbaar/domain/user/entity/User.java
@@ -35,9 +35,16 @@ public class User extends BaseEntityWithUpdate {
     @Column(name = "profile_image_url")
     private String profileImageUrl;
 
+    @Column(name = "refresh_token")
+    private String refreshToken;
+
     public User update(String nickname, String profileImageUrl) {
         this.nickname = nickname;
         this.profileImageUrl = profileImageUrl;
         return this;
+    }
+
+    public void updateRefreshToken(String refreshToken) {
+        this.refreshToken = refreshToken;
     }
 }

--- a/src/main/java/com/moonbaar/domain/user/entity/User.java
+++ b/src/main/java/com/moonbaar/domain/user/entity/User.java
@@ -34,4 +34,10 @@ public class User extends BaseEntityWithUpdate {
 
     @Column(name = "profile_image_url")
     private String profileImageUrl;
+
+    public User update(String nickname, String profileImageUrl) {
+        this.nickname = nickname;
+        this.profileImageUrl = profileImageUrl;
+        return this;
+    }
 }

--- a/src/main/java/com/moonbaar/domain/user/entity/User.java
+++ b/src/main/java/com/moonbaar/domain/user/entity/User.java
@@ -47,4 +47,9 @@ public class User extends BaseEntityWithUpdate {
     public void updateRefreshToken(String refreshToken) {
         this.refreshToken = refreshToken;
     }
+
+    public User removeRefreshToken() {
+        this.refreshToken = null;
+        return this;
+    }
 }

--- a/src/main/java/com/moonbaar/domain/user/exception/UserAccessDeniedException.java
+++ b/src/main/java/com/moonbaar/domain/user/exception/UserAccessDeniedException.java
@@ -1,0 +1,10 @@
+package com.moonbaar.domain.user.exception;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class UserAccessDeniedException extends BusinessException {
+    public UserAccessDeniedException() {
+        super(UserErrorCode.ACCESS_DENIED);
+    }
+
+}

--- a/src/main/java/com/moonbaar/domain/user/exception/UserErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/user/exception/UserErrorCode.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 public enum UserErrorCode implements ErrorCode {
 
     USER_NOT_FOUND("U001", "사용자를 찾을 수 없습니다.", HttpStatus.NOT_FOUND),
+    ACCESS_DENIED("U002", "접근 권한이 없습니다.", HttpStatus.UNAUTHORIZED),
     ;
 
     private final String code;

--- a/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
@@ -2,6 +2,13 @@ package com.moonbaar.domain.user.repository;
 
 import com.moonbaar.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
+@Repository
 public interface UserRepository extends JpaRepository<User, Long> {
+
+    Optional<User> findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
+
 }

--- a/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
@@ -11,4 +11,6 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
 
+    Optional<User> findById(Long id);
+
 }

--- a/src/main/java/com/moonbaar/domain/user/service/UserService.java
+++ b/src/main/java/com/moonbaar/domain/user/service/UserService.java
@@ -1,0 +1,24 @@
+package com.moonbaar.domain.user.service;
+
+
+import com.moonbaar.common.dto.OAuthAttributes;
+import com.moonbaar.domain.user.entity.User;
+import com.moonbaar.domain.user.repository.UserRepository;
+import jakarta.transaction.Transactional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+
+    @Transactional
+    public User saveOrUpdate(OAuthAttributes attributes, String registrationId) {
+        return userRepository.findByOauthIdAndOauthProvider(attributes.oauthId(), registrationId)
+                .map(entity -> entity.update(attributes.nickname(), attributes.profileImageUrl()))
+                .orElseGet(() -> userRepository.save(attributes.toEntity()));
+    }
+
+}

--- a/src/main/java/com/moonbaar/domain/user/service/UserService.java
+++ b/src/main/java/com/moonbaar/domain/user/service/UserService.java
@@ -1,7 +1,7 @@
 package com.moonbaar.domain.user.service;
 
 
-import com.moonbaar.common.dto.OAuthAttributes;
+import com.moonbaar.common.oauth.dto.OAuthAttributes;
 import com.moonbaar.domain.user.entity.User;
 import com.moonbaar.domain.user.repository.UserRepository;
 import jakarta.transaction.Transactional;

--- a/src/main/java/com/moonbaar/domain/user/service/UserService.java
+++ b/src/main/java/com/moonbaar/domain/user/service/UserService.java
@@ -14,6 +14,7 @@ import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import java.time.LocalDateTime;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -23,6 +24,9 @@ public class UserService {
     private final UserRepository userRepository;
     private final JwtUtils jwtUtils;
     private final TokenBlackList tokenBlackList;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpirationMs;
 
     @Transactional
     public User saveOrUpdate(OAuthAttributes attributes, String registrationId) {
@@ -60,7 +64,7 @@ public class UserService {
         accessCookie.setHttpOnly(true);
         accessCookie.setSecure(true);
         accessCookie.setPath("/");
-        accessCookie.setMaxAge(60 * 30); // 30분
+        accessCookie.setMaxAge((int) (accessTokenExpirationMs / 1000));
         accessCookie.setAttribute("SameSite", "Lax");
 
         response.addCookie(accessCookie);

--- a/src/main/java/com/moonbaar/domain/user/service/UserService.java
+++ b/src/main/java/com/moonbaar/domain/user/service/UserService.java
@@ -2,8 +2,14 @@ package com.moonbaar.domain.user.service;
 
 
 import com.moonbaar.common.oauth.dto.OAuthAttributes;
+import com.moonbaar.common.utils.JwtUtils;
 import com.moonbaar.domain.user.entity.User;
+import com.moonbaar.domain.user.exception.UserAccessDeniedException;
+import com.moonbaar.domain.user.exception.UserNotFoundException;
 import com.moonbaar.domain.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,6 +19,7 @@ import org.springframework.stereotype.Service;
 public class UserService {
 
     private final UserRepository userRepository;
+    private final JwtUtils jwtUtils;
 
     @Transactional
     public User saveOrUpdate(OAuthAttributes attributes, String registrationId) {
@@ -21,4 +28,55 @@ public class UserService {
                 .orElseGet(() -> userRepository.save(attributes.toEntity()));
     }
 
+    // Refresh Token로 Access Token 재발급
+    public void refreshAccessToken(HttpServletRequest request, HttpServletResponse response) {
+        // 쿠키에서 refreshToken 추출
+        String refreshToken = getCookieValueByName(request, "refreshToken");
+
+        // refreshToken 누락
+        if (refreshToken == null) {
+            throw new UserAccessDeniedException();
+        }
+
+        // 유효하지 않은 토큰
+        if (!jwtUtils.isValid(refreshToken)) {
+            throw new UserAccessDeniedException();
+        }
+
+        // DB에 저장된 refreshToken과 비교
+        Long userId = jwtUtils.getUserId(refreshToken);
+        User user = userRepository.findById(userId).orElseThrow(() -> new UserNotFoundException());
+        if (!refreshToken.equals(user.getRefreshToken())) {
+            throw new UserAccessDeniedException();
+        }
+
+        // Access Token 새로 발급
+        String accessToken = jwtUtils.generateAccessToken(userId);
+
+        Cookie accessCookie = new Cookie("accessToken", accessToken);
+        accessCookie.setHttpOnly(true);
+        accessCookie.setSecure(true);
+        accessCookie.setPath("/");
+        accessCookie.setMaxAge(60 * 30); // 30분
+        accessCookie.setAttribute("SameSite", "Lax");
+
+        response.addCookie(accessCookie);
+    }
+
+
+    /**
+     * 요청에서 특정 이름의 쿠키 값을 반환
+     * @param request   HttpServletRequest 객체
+     * @param name      찾고자 하는 Cookie 이름
+     * @return          찾고자 하는 Cookie 값, 없으면 null
+     */
+    private String getCookieValueByName(HttpServletRequest request, String name) {
+        if (request.getCookies() == null) return null;
+        for (Cookie cookie : request.getCookies()) {
+            if (cookie.getName().equals(name)) {
+                return cookie.getValue();
+            }
+        }
+        return null;
+    }
 }


### PR DESCRIPTION
## 이슈
- #6 

## 주요 변경 사항
> OAuth2 소셜 로그인 기능을 구현하고 JWT 기반 인증 처리 구현

1. **네이버/카카오 OAuth2 로그인 구현**
- `SecurityConfig` 설정
- `CustomOAuth2UserService`로 사용자 정보를 가져오고, `OAuthAttributes`을 이용해 사용자 정보를 같은 형태로 관리
- `OAuth2SuccessHandler`에서 토큰 관련 처리 후 `/login-success`로 리다이렉트

2. **JWT 기반 인증 처리**
- `JwtUtils`에서 Access Token/Refresh Token 을 생성 및 관리
- Access Token이 만료 되었을 때 Refresh Token으로 재발급 가능하도록 `POST/users/refresh` 구현
- Refresh Token을 DB에서 제거하고 Access Token을 `TokenBlackList`에 추가하는 `POST/users/logout` 구현
- JWT를 검증하는 `JwtAuthenticationFilter` 구현

## 세부 설명
.

## 다음 작업
- 인증/인가 관련 `/users/logout`, `/users/refresh` 등을 `/auth/logout` 등 `auth`로 변경하거나 필터 제외할 경로를 세분화
- `JwtAuthenticationFilter`에서도 `GlobalExceptionHandler` 처리
- 인메모리로 방식인 `TokenBlackList`를 Redis 등을 사용하여 관리하도록 변경