### PR TITLE
refactor: 좋아요 목록 조회 api 응답 필드명 변경

### DIFF
--- a/src/main/java/com/moonbaar/domain/like/dto/LikedEventListResponse.java
+++ b/src/main/java/com/moonbaar/domain/like/dto/LikedEventListResponse.java
@@ -8,7 +8,7 @@ public record LikedEventListResponse(
         Long totalCount,
         int totalPages,
         int currentPage,
-        List<LikedEventResponse> likes
+        List<LikedEventResponse> events
 ) {
 
     public static LikedEventListResponse from(Page<LikedEvent> likedEvents) {

--- a/src/main/java/com/moonbaar/domain/like/dto/LikedEventResponse.java
+++ b/src/main/java/com/moonbaar/domain/like/dto/LikedEventResponse.java
@@ -11,8 +11,7 @@ public record LikedEventResponse(
         String place,
         LocalDateTime startDate,
         LocalDateTime endDate,
-        String mainImg,
-        LocalDateTime likedAt
+        String mainImg
 ) {
 
     public static LikedEventResponse from(LikedEvent likedEvent) {
@@ -23,8 +22,7 @@ public record LikedEventResponse(
                 event.getPlace(),
                 event.getStartDate(),
                 event.getEndDate(),
-                event.getMainImg(),
-                likedEvent.getCreatedAt()
+                event.getMainImg()
         );
     }
 

--- a/src/main/java/com/moonbaar/domain/like/dto/LikedEventResponse.java
+++ b/src/main/java/com/moonbaar/domain/like/dto/LikedEventResponse.java
@@ -6,7 +6,7 @@ import java.time.LocalDateTime;
 import java.util.List;
 
 public record LikedEventResponse(
-        Long eventId,
+        Long id,
         String title,
         String place,
         LocalDateTime startDate,

--- a/src/test/java/com/moonbaar/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/user/controller/UserControllerTest.java
@@ -44,13 +44,11 @@ public class UserControllerTest {
         LocalDateTime now = LocalDateTime.now();
         LikedEventResponse event1 = new LikedEventResponse(
                 1L, "서울시극단 [코믹]", "세종M씨어터",
-                now.plusDays(1), now.plusDays(3), "https://example.com/image1.jpg",
-                now.minusDays(1));
+                now.plusDays(1), now.plusDays(3), "https://example.com/image1.jpg");
 
         LikedEventResponse event2 = new LikedEventResponse(
                 2L, "[노원문화원] 국악예술단 정기공연", "노원문화예술회관 대공연장",
-                now.plusDays(2), now.plusDays(4), "https://example.com/image2.jpg",
-                now.minusDays(2));
+                now.plusDays(2), now.plusDays(4), "https://example.com/image2.jpg");
 
         LikedEventListResponse response = new LikedEventListResponse(
                 2L, 1, 1, List.of(event1, event2));

--- a/src/test/java/com/moonbaar/domain/user/controller/UserControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/user/controller/UserControllerTest.java
@@ -67,12 +67,12 @@ public class UserControllerTest {
                 .andExpect(jsonPath("$.totalCount").value(2))
                 .andExpect(jsonPath("$.totalPages").value(1))
                 .andExpect(jsonPath("$.currentPage").value(1))
-                .andExpect(jsonPath("$.likes").isArray())
-                .andExpect(jsonPath("$.likes.length()").value(2))
-                .andExpect(jsonPath("$.likes[0].eventId").value(1))
-                .andExpect(jsonPath("$.likes[0].title").value("서울시극단 [코믹]"))
-                .andExpect(jsonPath("$.likes[1].eventId").value(2))
-                .andExpect(jsonPath("$.likes[1].title").value("[노원문화원] 국악예술단 정기공연"));
+                .andExpect(jsonPath("$.events").isArray())
+                .andExpect(jsonPath("$.events.length()").value(2))
+                .andExpect(jsonPath("$.events[0].id").value(1))
+                .andExpect(jsonPath("$.events[0].title").value("서울시극단 [코믹]"))
+                .andExpect(jsonPath("$.events[1].id").value(2))
+                .andExpect(jsonPath("$.events[1].title").value("[노원문화원] 국악예술단 정기공연"));
 
         // 서비스에 전달된 요청 객체 검증
         LikedEventListRequest capturedRequest = requestCaptor.getValue();


### PR DESCRIPTION
## 세부 설명
- 좋아요 목록 조회 응답 필드명을
행사 목록 조회 응답 필드명과 통일되게 변경하였습니다.
``likes`` -> ``events``
``eventId`` -> ``id``

- 불필요한 ``likedAt`` 필드를 제거하였습니다.

## 응답 예시
```json
{ "totalCount": 15, "totalPages": 1, "currentPage": 1, "events": [ { "id": "이벤트ID", "title": "행사명", "place": "장소명", "startDate": "2025-04-10T10:00:00Z", "endDate": "2025-04-10T18:00:00Z", "mainImg": "이미지URL" }, ... ] }
```