### PR TITLE
feat: 발자국 지도(지도 범위 기반 방문 위치 조회) api 구현

### DIFF
--- a/src/main/java/com/moonbaar/domain/visit/controller/FootPrintController.java
+++ b/src/main/java/com/moonbaar/domain/visit/controller/FootPrintController.java
@@ -2,6 +2,7 @@ package com.moonbaar.domain.visit.controller;
 
 import com.moonbaar.domain.visit.dto.FootprintListResponse;
 import com.moonbaar.domain.visit.dto.FootprintRequest;
+import com.moonbaar.domain.visit.service.FootprintService;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
@@ -17,11 +18,16 @@ import org.springframework.web.bind.annotation.RestController;
 @Validated
 public class FootPrintController {
 
+    // 임시 유저 아이디
+    private Long MOCK_USER_ID = 1L;
+
+    private final FootprintService footprintService;
+
     @GetMapping("/me/footprints")
-    public ResponseEntity<FootprintListResponse> getUserFootPrints(
+    public ResponseEntity<FootprintListResponse> getUserFootprints(
             @ModelAttribute @Valid FootprintRequest request) {
 
-        FootprintListResponse response;
-        return response;
+        FootprintListResponse response = footprintService.findUserFootprints(MOCK_USER_ID, request);
+        return ResponseEntity.ok(response);
     }
 }

--- a/src/main/java/com/moonbaar/domain/visit/controller/FootPrintController.java
+++ b/src/main/java/com/moonbaar/domain/visit/controller/FootPrintController.java
@@ -1,0 +1,27 @@
+package com.moonbaar.domain.visit.controller;
+
+import com.moonbaar.domain.visit.dto.FootprintListResponse;
+import com.moonbaar.domain.visit.dto.FootprintRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+@Validated
+public class FootPrintController {
+
+    @GetMapping("/me/footprints")
+    public ResponseEntity<FootprintListResponse> getUserFootPrints(
+            @ModelAttribute @Valid FootprintRequest request) {
+
+        FootprintListResponse response;
+        return response;
+    }
+}

--- a/src/main/java/com/moonbaar/domain/visit/controller/FootprintController.java
+++ b/src/main/java/com/moonbaar/domain/visit/controller/FootprintController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users")
 @RequiredArgsConstructor
 @Validated
-public class FootPrintController {
+public class FootprintController {
 
     // 임시 유저 아이디
     private Long MOCK_USER_ID = 1L;

--- a/src/main/java/com/moonbaar/domain/visit/dto/FootprintListResponse.java
+++ b/src/main/java/com/moonbaar/domain/visit/dto/FootprintListResponse.java
@@ -1,0 +1,16 @@
+package com.moonbaar.domain.visit.dto;
+
+import com.moonbaar.domain.visit.entity.Visit;
+import java.util.List;
+
+public record FootprintListResponse(
+        List<FootprintResponse> events
+) {
+
+    public static FootprintListResponse from(List<Visit> visits) {
+        List<FootprintResponse> events = visits.stream()
+                .map(FootprintResponse::from)
+                .toList();
+        return new FootprintListResponse(events);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/visit/dto/FootprintRequest.java
+++ b/src/main/java/com/moonbaar/domain/visit/dto/FootprintRequest.java
@@ -7,11 +7,11 @@ public record FootprintRequest(
         @NotNull(message = "최소 위도는 필수 입력값입니다")
         BigDecimal minLat,
 
-        @NotNull(message = "최소 경도는 필수 입력값입니다")
-        BigDecimal minLng,
-
         @NotNull(message = "최대 위도는 필수 입력값입니다")
         BigDecimal maxLat,
+
+        @NotNull(message = "최소 경도는 필수 입력값입니다")
+        BigDecimal minLng,
 
         @NotNull(message = "최대 경도는 필수 입력값입니다")
         BigDecimal maxLng

--- a/src/main/java/com/moonbaar/domain/visit/dto/FootprintRequest.java
+++ b/src/main/java/com/moonbaar/domain/visit/dto/FootprintRequest.java
@@ -1,0 +1,19 @@
+package com.moonbaar.domain.visit.dto;
+
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+public record FootprintRequest(
+        @NotNull(message = "최소 위도는 필수 입력값입니다")
+        BigDecimal minLat,
+
+        @NotNull(message = "최소 경도는 필수 입력값입니다")
+        BigDecimal minLng,
+
+        @NotNull(message = "최대 위도는 필수 입력값입니다")
+        BigDecimal maxLat,
+
+        @NotNull(message = "최대 경도는 필수 입력값입니다")
+        BigDecimal maxLng
+) {
+}

--- a/src/main/java/com/moonbaar/domain/visit/dto/FootprintResponse.java
+++ b/src/main/java/com/moonbaar/domain/visit/dto/FootprintResponse.java
@@ -1,0 +1,31 @@
+package com.moonbaar.domain.visit.dto;
+
+import com.moonbaar.domain.event.entity.CulturalEvent;
+import com.moonbaar.domain.visit.entity.Visit;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+
+public record FootprintResponse(
+        Long id,
+        String title,
+        String place,
+        String mainImg,
+        BigDecimal latitude,
+        BigDecimal longitude,
+        LocalDateTime visitedAt
+) {
+
+    public static FootprintResponse from(Visit visit) {
+        CulturalEvent event = visit.getEvent();
+
+        return new FootprintResponse(
+                visit.getId(),
+                event.getTitle(),
+                event.getPlace(),
+                event.getMainImg(),
+                event.getLatitude(),
+                event.getLongitude(),
+                visit.getVisitedAt()
+        );
+    }
+}

--- a/src/main/java/com/moonbaar/domain/visit/repository/VisitRepository.java
+++ b/src/main/java/com/moonbaar/domain/visit/repository/VisitRepository.java
@@ -3,12 +3,30 @@ package com.moonbaar.domain.visit.repository;
 import com.moonbaar.domain.event.entity.CulturalEvent;
 import com.moonbaar.domain.user.entity.User;
 import com.moonbaar.domain.visit.entity.Visit;
+import java.math.BigDecimal;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface VisitRepository extends JpaRepository<Visit, Long> {
 
     Optional<Visit> findTopByUserAndEventOrderByVisitedAtDesc(User user, CulturalEvent event);
+
+    @Query("SELECT v FROM Visit v " +
+            "JOIN FETCH v.event e " +
+            "WHERE v.user.id = :userId " +
+            "AND e.latitude >= :minLat " +
+            "AND e.latitude <= :maxLat " +
+            "AND e.longitude >= :minLng " +
+            "AND e.longitude <= :maxLng ")
+    List<Visit> findFootprintsByUserIdAndBounds(
+            @Param("userId") Long userId,
+            @Param("minLat") BigDecimal minLat,
+            @Param("maxLat") BigDecimal maxLat,
+            @Param("minLng") BigDecimal minLng,
+            @Param("maxLng") BigDecimal maxLng);
 }

--- a/src/main/java/com/moonbaar/domain/visit/service/FootprintService.java
+++ b/src/main/java/com/moonbaar/domain/visit/service/FootprintService.java
@@ -1,0 +1,27 @@
+package com.moonbaar.domain.visit.service;
+
+import com.moonbaar.domain.visit.dto.FootprintListResponse;
+import com.moonbaar.domain.visit.dto.FootprintRequest;
+import com.moonbaar.domain.visit.entity.Visit;
+import com.moonbaar.domain.visit.repository.VisitRepository;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class FootprintService {
+
+    private final VisitRepository visitRepository;
+
+    public FootprintListResponse findUserFootprints(Long userId, FootprintRequest request) {
+        List<Visit> visits = visitRepository.findFootprintsByUserIdAndBounds(
+                userId,
+                request.minLat(),
+                request.maxLat(),
+                request.minLng(),
+                request.maxLng()
+        );
+        return FootprintListResponse.from(visits);
+    }
+}

--- a/src/test/java/com/moonbaar/domain/visit/controller/FootprintControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/visit/controller/FootprintControllerTest.java
@@ -26,7 +26,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import org.springframework.test.web.servlet.MockMvc;
 
-@WebMvcTest(FootPrintController.class)
+@WebMvcTest(FootprintController.class)
 @Import(SecurityTestConfig.class)
 @AutoConfigureMockMvc(addFilters = false)
 public class FootprintControllerTest {

--- a/src/test/java/com/moonbaar/domain/visit/controller/FootprintControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/visit/controller/FootprintControllerTest.java
@@ -1,0 +1,150 @@
+package com.moonbaar.domain.visit.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.moonbaar.common.config.SecurityTestConfig;
+import com.moonbaar.domain.visit.dto.FootprintListResponse;
+import com.moonbaar.domain.visit.dto.FootprintRequest;
+import com.moonbaar.domain.visit.dto.FootprintResponse;
+import com.moonbaar.domain.visit.service.FootprintService;
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(FootPrintController.class)
+@Import(SecurityTestConfig.class)
+@AutoConfigureMockMvc(addFilters = false)
+public class FootprintControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ObjectMapper objectMapper;
+
+    @MockitoBean
+    private FootprintService footprintService;
+
+    private final Long MOCK_USER_ID = 1L;
+    private final Long EVENT_ID = 1L;
+
+    @Test
+    @DisplayName("지도 범위 내 방문 위치 조회 성공")
+    void getUserFootprints_ReturnsFootprints() throws Exception {
+        // Given
+        FootprintResponse footprint1 = new FootprintResponse(
+                1L,
+                "연극 '환상동화'",
+                "세종문화회관 세종M씨어터",
+                "https://example.com/image1.jpg",
+                new BigDecimal("37.5725"),
+                new BigDecimal("126.9760"),
+                LocalDateTime.now().minusDays(5)
+        );
+
+        FootprintResponse footprint2 = new FootprintResponse(
+                2L,
+                "노원문화예술회관 국악예술단 정기공연",
+                "노원문화예술회관 대공연장",
+                "https://example.com/image2.jpg",
+                new BigDecimal("37.6523"),
+                new BigDecimal("127.0723"),
+                LocalDateTime.now().minusDays(2)
+        );
+
+        FootprintListResponse response = new FootprintListResponse(List.of(footprint1, footprint2));
+
+        when(footprintService.findUserFootprints(eq(MOCK_USER_ID), any(FootprintRequest.class)))
+                .thenReturn(response);
+
+        // When & Then
+        mockMvc.perform(get("/users/me/footprints")
+                        .param("minLat", "37.5000")
+                        .param("maxLat", "37.7000")
+                        .param("minLng", "126.9000")
+                        .param("maxLng", "127.1000")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.events").isArray())
+                .andExpect(jsonPath("$.events.length()").value(2))
+                .andExpect(jsonPath("$.events[0].id").value(1))
+                .andExpect(jsonPath("$.events[0].title").value("연극 '환상동화'"))
+                .andExpect(jsonPath("$.events[0].place").value("세종문화회관 세종M씨어터"))
+                .andExpect(jsonPath("$.events[0].latitude").value(37.5725))
+                .andExpect(jsonPath("$.events[0].longitude").value(126.9760))
+                .andExpect(jsonPath("$.events[1].id").value(2))
+                .andExpect(jsonPath("$.events[1].title").value("노원문화예술회관 국악예술단 정기공연"));
+    }
+
+    @Test
+    @DisplayName("필수 파라미터 누락 시 400 응답을 반환해야 한다")
+    void getUserFootprints_WithMissingParameters_ReturnsBadRequest() throws Exception {
+        // When & Then - minLat 파라미터 누락
+        mockMvc.perform(get("/users/me/footprints")
+                        .param("maxLat", "37.7000")
+                        .param("minLng", "126.9000")
+                        .param("maxLng", "127.1000")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        // When & Then - maxLat 파라미터 누락
+        mockMvc.perform(get("/users/me/footprints")
+                        .param("minLat", "37.5000")
+                        .param("minLng", "126.9000")
+                        .param("maxLng", "127.1000")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        // When & Then - minLng 파라미터 누락
+        mockMvc.perform(get("/users/me/footprints")
+                        .param("minLat", "37.5000")
+                        .param("maxLat", "37.7000")
+                        .param("maxLng", "127.1000")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+
+        // When & Then - maxLng 파라미터 누락
+        mockMvc.perform(get("/users/me/footprints")
+                        .param("minLat", "37.5000")
+                        .param("maxLat", "37.7000")
+                        .param("minLng", "126.9000")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+
+    @Test
+    @DisplayName("빈 결과 반환 처리 테스트")
+    void getUserFootprints_WithNoResults_ReturnsEmptyList() throws Exception {
+        // Given
+        FootprintListResponse emptyResponse = new FootprintListResponse(List.of());
+
+        when(footprintService.findUserFootprints(eq(MOCK_USER_ID), any(FootprintRequest.class)))
+                .thenReturn(emptyResponse);
+
+        // When & Then
+        mockMvc.perform(get("/users/me/footprints")
+                        .param("minLat", "37.5000")
+                        .param("maxLat", "37.7000")
+                        .param("minLng", "126.9000")
+                        .param("maxLng", "127.1000")
+                        .contentType(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.events").isArray())
+                .andExpect(jsonPath("$.events.length()").value(0));
+    }
+}


### PR DESCRIPTION
## 이슈
- #23 

## 변경 사항
- 지도에 방문 이력 표시를 위한 `/users/me/footprints` API 구현
  - 지도 범위(bounds) 내 방문 장소만 필터링하는 기능 구현
  - 필요한 DTO, 서비스, 레포지토리 로직 구현
  - 테스트 코드 추가 (컨트롤러, 서비스, 레포지토리)

## 세부 설명

### 1. 지도 범위 기반 조회 API 구현
- `/users/me/footprints` 엔드포인트로 사용자가 방문한 위치를 지도에 표시할 수 있도록 구현했습니다.
- 지도에 보이는 영역(bounds)에 해당하는 방문 기록만 효율적으로 가져오기 위해 위도/경도 범위 기반 쿼리를 작성했습니다.
- 필수 파라미터(minLat, maxLat, minLng, maxLng)를 통해 지도 범위를 지정하도록 했습니다.

<img width="500" alt="image" src="https://github.com/user-attachments/assets/775cc62b-b798-48a8-a0d9-c051788a3d14" />

### 2. N+1 문제 해결을 위한 JPQL 쿼리 최적화

#### 페치 조인을 적용하기 전 쿼리

Visit 엔티티에 CulturalEvent가 지연 로딩으로 설정되어 있어
방문 목록을 가져오고, 해당하는 이벤트 정보를 반환하는 로직에서 N+1 Query 문제가 발생했었습니다.

```
// Visit 엔티티를 조회하는 쿼리 (1개)
Hibernate: 
    select
        v1_0.id,
        v1_0.created_at,
        v1_0.event_id,
        v1_0.user_id,
        v1_0.visited_at 
    from
        visits v1_0 
    join
        cultural_events e1_0 
            on e1_0.id=v1_0.event_id 
    where
        v1_0.user_id=? 
        and e1_0.latitude>=? 
        and e1_0.latitude<=? 
        and e1_0.longitude>=? 
        and e1_0.longitude<=?

// 이후 각 Visit에 대해 CulturalEvent를 조회하는 쿼리 (N개)
Hibernate: 
    select
        ce1_0.id,
        ce1_0.api_last_updated,
        ce1_0.category_id,
        ce1_0.created_at,
        ce1_0.district_id,
        ce1_0.end_date,
        ...
    from
        cultural_events ce1_0 
    where
        ce1_0.id=?
Hibernate: 
    select
        ce1_0.id,
        ce1_0.api_last_updated,
        ce1_0.category_id,
        ce1_0.created_at,
        ce1_0.district_id,
        ce1_0.end_date,
        ...
    from
        cultural_events ce1_0 
    where
        ce1_0.id=?
```

#### 개선된 JPQL 조인 전략
```java
@Query("SELECT v FROM Visit v " +
       "JOIN FETCH v.event e " +
       "WHERE v.user.id = :userId " +
       "AND e.latitude >= :minLat " +
       "AND e.latitude <= :maxLat " +
       "AND e.longitude >= :minLng " +
       "AND e.longitude <= :maxLng ")
List<Visit> findFootprintsByUserIdAndBounds(...);
```

#### 페치 조인을 적용한 후 쿼리
```
// events를 inner join한 후 한번에 가져옴(1개)
Hibernate: 
    select
        v1_0.id,
        v1_0.created_at,
        v1_0.event_id,
        e1_0.id,
        e1_0.api_last_updated,
        e1_0.category_id,
        ...,
        e1_0.use_fee,
        e1_0.use_trgt,
        v1_0.user_id,
        v1_0.visited_at 
    from
        visits v1_0 
    join
        cultural_events e1_0 
            on e1_0.id=v1_0.event_id 
    where
        v1_0.user_id=? 
        and e1_0.latitude>=? 
        and e1_0.latitude<=? 
        and e1_0.longitude>=? 
        and e1_0.longitude<=?
```

- **JOIN FETCH**를 사용하여 Visit, Event 엔티티를 한 번의 쿼리로 함께 로딩
- 발자국 지도 목록 조회 시 최대 1번의 쿼리만 실행되도록 최적화
- LAZY 로딩으로 설정된 연관 관계를 미리 로딩하여 N+1 문제 방지

## 다음 할 일
이번에 N+1 Query 문제를 고려해서 api를 구현해보았는데
이전에 좋아요 목록 api도 N+1 문제를 고려했어야 했다는 걸 깨달았습니다🥲

좋아요 목록 응답의 경우 페이징을 적용하고 있는데 페이징과 fetch join 사용은 jpa에서 막혀 있다고 합니다. 그래서 다른 방법이 필요할 것 같습니다.
더 공부해서 좋아요 목록 api도 리팩토링해 볼 예정입니다. 