### PR TITLE
feat: 사용자 관련 api 구현

### DIFF
--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -2,6 +2,7 @@ package com.moonbaar.common.config;
 
 import com.moonbaar.common.filter.JwtAuthenticationFilter;
 import com.moonbaar.common.oauth.handler.OAuth2SuccessHandler;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -33,7 +34,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/login", "/oauth2/**", "/events/**", "/categories/**", "/districts/**", "/users/**").permitAll()  // 공개 API 경로
+                        .requestMatchers("/login", "/oauth2/**", "/events/**", "/categories/**", "/districts/**", "/users/refresh").permitAll()  // 공개 API 경로
                         .anyRequest().authenticated()  // 나머지 경로는 인증 필요
                 )
                 .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class)
@@ -41,6 +42,13 @@ public class SecurityConfig {
                 // OAuth2 로그인 설정
                 .formLogin(form -> form.disable())
                 .logout(logout -> logout.disable())
+
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
+                        })
+                )
+
                 .oauth2Login(oauth -> oauth
                         // 로그인 후 사용자 정보 가져올 때 사용할 서비스 지정
                         .userInfoEndpoint(userInfo -> userInfo .userService(customOAuth2UserService))

--- a/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
@@ -1,16 +1,21 @@
 package com.moonbaar.common.filter;
 
 import com.moonbaar.common.oauth.TokenBlackList;
+import com.moonbaar.common.oauth.service.CustomUserDetailsService;
 import com.moonbaar.common.utils.JwtUtils;
 import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
 import java.io.IOException;
+import java.util.List;
 
 @Component
 @RequiredArgsConstructor
@@ -18,6 +23,7 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
 
     private final JwtUtils jwtUtils;
     private final TokenBlackList tokenBlackList;
+    private final CustomUserDetailsService userDetailsService;
 
     @Override
     protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response,
@@ -27,6 +33,12 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
             response.sendError(HttpServletResponse.SC_UNAUTHORIZED);
             return;
         }
+
+        // 인증 객체 생성 및 SecurityContext 등록
+        Long userId = jwtUtils.getUserId(accessToken);
+        UserDetails userDetails = userDetailsService.loadUserByUsername(String.valueOf(userId));
+        UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(userDetails, null, List.of());
+        SecurityContextHolder.getContext().setAuthentication(authentication);
 
         filterChain.doFilter(request, response);
     }

--- a/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
+++ b/src/main/java/com/moonbaar/common/filter/JwtAuthenticationFilter.java
@@ -51,6 +51,6 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
                 path.startsWith("/api/events") ||
                 path.startsWith("/api/categories") ||
                 path.startsWith("/api/districts") ||
-                path.startsWith("/api/users");
+                path.startsWith("/api/users/refresh");
     }
 }

--- a/src/main/java/com/moonbaar/common/oauth/CustomUserDetails.java
+++ b/src/main/java/com/moonbaar/common/oauth/CustomUserDetails.java
@@ -1,0 +1,52 @@
+package com.moonbaar.common.oauth;
+
+import com.moonbaar.domain.user.entity.User;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.List;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final User user;
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(user.getId());
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return List.of();
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return UserDetails.super.isAccountNonExpired();
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return UserDetails.super.isAccountNonLocked();
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return UserDetails.super.isCredentialsNonExpired();
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return UserDetails.super.isEnabled();
+    }
+}

--- a/src/main/java/com/moonbaar/common/oauth/service/CustomUserDetailsService.java
+++ b/src/main/java/com/moonbaar/common/oauth/service/CustomUserDetailsService.java
@@ -1,0 +1,24 @@
+package com.moonbaar.common.oauth.service;
+
+import com.moonbaar.common.oauth.CustomUserDetails;
+import com.moonbaar.domain.user.entity.User;
+import com.moonbaar.domain.user.exception.UserNotFoundException;
+import com.moonbaar.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.valueOf(username)).orElseThrow(UserNotFoundException::new);
+        return new CustomUserDetails(user);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
+++ b/src/main/java/com/moonbaar/domain/like/entity/LikedEvent.java
@@ -30,7 +30,12 @@ import lombok.NoArgsConstructor;
 public class LikedEvent extends BaseEntity {
 
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(
+                    name = "fk_liked_event_user_id",
+                    foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+            )
+    )
     private User user;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/com/moonbaar/domain/user/controller/UserController.java
+++ b/src/main/java/com/moonbaar/domain/user/controller/UserController.java
@@ -1,11 +1,15 @@
 package com.moonbaar.domain.user.controller;
 
+import com.moonbaar.common.oauth.CustomUserDetails;
+import com.moonbaar.domain.user.dto.UserInfoResponse;
 import com.moonbaar.domain.user.service.UserService;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -28,5 +32,10 @@ public class UserController {
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         userService.logout(request, response);
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping("/me")
+    public ResponseEntity<UserInfoResponse> getLoginUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ResponseEntity.ok(UserInfoResponse.from(userDetails.getUser()));
     }
 }

--- a/src/main/java/com/moonbaar/domain/user/controller/UserController.java
+++ b/src/main/java/com/moonbaar/domain/user/controller/UserController.java
@@ -9,10 +9,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.validation.annotation.Validated;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/users")
@@ -37,5 +34,11 @@ public class UserController {
     @GetMapping("/me")
     public ResponseEntity<UserInfoResponse> getLoginUser(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return ResponseEntity.ok(UserInfoResponse.from(userDetails.getUser()));
+    }
+
+    @DeleteMapping("/me")
+    public ResponseEntity<Void> deleteLoginUser(HttpServletRequest request, HttpServletResponse response, @AuthenticationPrincipal CustomUserDetails userDetails) {
+        userService.deleteUser(request, response, userDetails.getUser().getId());
+        return ResponseEntity.noContent().build();
     }
 }

--- a/src/main/java/com/moonbaar/domain/user/dto/UserInfoResponse.java
+++ b/src/main/java/com/moonbaar/domain/user/dto/UserInfoResponse.java
@@ -1,0 +1,23 @@
+package com.moonbaar.domain.user.dto;
+
+import com.moonbaar.domain.user.entity.User;
+
+import java.time.LocalDateTime;
+
+public record UserInfoResponse(
+        Long id,
+        String nickname,
+        String profileImageUrl,
+        LocalDateTime createdAt,
+        LocalDateTime updatedAt
+) {
+    public static UserInfoResponse from(User user) {
+        return new UserInfoResponse(
+                user.getId(),
+                user.getNickname(),
+                user.getProfileImageUrl(),
+                user.getCreatedAt(),
+                user.getUpdatedAt()
+        );
+    }
+}

--- a/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
@@ -2,8 +2,6 @@ package com.moonbaar.domain.user.repository;
 
 import com.moonbaar.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
-import org.springframework.data.jpa.repository.Modifying;
-import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,13 +10,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
-
-    Optional<User> findById(Long id);
-
-    boolean existsById(Long id);
-
-    @Modifying
-    @Query(value = "DELETE FROM users WHERE id = :id", nativeQuery = true)
-    void deleteById(Long id);
 
 }

--- a/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
+++ b/src/main/java/com/moonbaar/domain/user/repository/UserRepository.java
@@ -2,6 +2,8 @@ package com.moonbaar.domain.user.repository;
 
 import com.moonbaar.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 import java.util.Optional;
@@ -12,5 +14,11 @@ public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByOauthIdAndOauthProvider(String oauthId, String oauthProvider);
 
     Optional<User> findById(Long id);
+
+    boolean existsById(Long id);
+
+    @Modifying
+    @Query(value = "DELETE FROM users WHERE id = :id", nativeQuery = true)
+    void deleteById(Long id);
 
 }

--- a/src/main/java/com/moonbaar/domain/user/service/UserService.java
+++ b/src/main/java/com/moonbaar/domain/user/service/UserService.java
@@ -104,4 +104,11 @@ public class UserService {
         return userRepository.findById(userId)
                 .orElseThrow(UserNotFoundException::new);
     }
+
+    @Transactional
+    public void deleteUser(HttpServletRequest request, HttpServletResponse response, Long userId) {
+        // TODO 소셜 인증 철회
+        logout(request, response);
+        userRepository.deleteById(userId);
+    }
 }

--- a/src/main/java/com/moonbaar/domain/visit/entity/Visit.java
+++ b/src/main/java/com/moonbaar/domain/visit/entity/Visit.java
@@ -6,6 +6,7 @@ import com.moonbaar.domain.user.entity.User;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
+import jakarta.persistence.ForeignKey;
 import jakarta.persistence.JoinColumn;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
@@ -27,7 +28,12 @@ public class Visit extends BaseEntity {
 
     @NotNull
     @ManyToOne(fetch = FetchType.LAZY)
-    @JoinColumn(name = "user_id", nullable = false)
+    @JoinColumn(name = "user_id", nullable = false,
+            foreignKey = @ForeignKey(
+                    name = "fk_visit_user_id",
+                    foreignKeyDefinition = "FOREIGN KEY (user_id) REFERENCES users(id) ON DELETE CASCADE"
+            )
+    )
     private User user;
 
     @NotNull


### PR DESCRIPTION
## 이슈
- #42 

## 주요 변경 사항
> 로그인된 사용자 정보 조회 및 회원 탈퇴 기능 구현

1. `UserDetails`를 `SecurityContext`에 등록하여 `@AuthenticationPrincipal` 으로 로그인된 사용자 정보를 확인할 수 있도록 했습니다.

2. 인증 예외 처리 EntryPoint를 설정하여 JWT 인증 실패시 401로 응답하도록하였습니다.
추후 클래스를 직접 구현하여 `GlobalExceptionHandler`를 사용하도록 변경할 예정입니다.

3. 사용자 정보를 조회하는 `GET /users/me` 엔드포인트를 구현했습니다.

4. 사용자 정보를 삭제하는 `DELETE /users/me` 엔드포인트를 구현했습니다.
회원탈퇴시 사용자의 방문 데이터와 좋아요 데이터를 같이 삭제할 수 있도록 `DELETE CASCADE` 제약조건을 추가하였습니다.
JPA에서 `User`와 `Visit`/`LikedEvent`를 양방향 처리하지 않고 DB 상에서 CASCADE 될 수 있도록 하였습니다.

소셜로그인 인증 철회는 추후 구현할 예정입니다.
1. Kakao의 경우 access token이 필요하여 로그인시 이를 따로 관리하는 로직이 필요합니다.
3. 외부 API이용에 따른 트랜잭션 분리 및 인증 철회 실패시 재시도에 관한 로직을 고려해야합니다.

## 세부 설명
.

## 다음 작업
- `AuthenticationEntryPoint` 구현 및  `GlobalExceptionHandler` 적용
- 로그아웃에 사용되는 accessToken/refreshToken 만료 로직을 분리하여 재사용할 수 있도록 함
- kakao 로그인 시 access token 관리
- 소셜로그인 인증 철회 트랜잭션 분리 및 실패 재시도 로직을 구현하거나 회원탈퇴 로직을 중지하는 로직 구현