### PR TITLE
feat: 배지 api 구현

### DIFF
--- a/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
@@ -1,6 +1,7 @@
 package com.moonbaar.domain.badge.controller;
 
 import com.moonbaar.common.oauth.CustomUserDetails;
+import com.moonbaar.domain.badge.dto.BadgeListResponse;
 import com.moonbaar.domain.badge.dto.BadgeProgressResponse;
 import com.moonbaar.domain.badge.dto.UserBadgeListResponse;
 import com.moonbaar.domain.badge.service.BadgeService;
@@ -17,11 +18,12 @@ public class BadgeController {
     private final BadgeService badgeService;
 
     /**
+     * 전체 배지 목록과 사용자의 소유 여부를 조회한다.
      * @param userDetails 로그인된 사용자
      * @return 사용자가 보유한 배지 목록
      */
     @GetMapping
-    public UserBadgeListResponse findBadges(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public BadgeListResponse findBadges(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return badgeService.findUserBadges(userDetails.getUser());
     }
 

--- a/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
@@ -1,0 +1,26 @@
+package com.moonbaar.domain.badge.controller;
+
+import com.moonbaar.common.oauth.CustomUserDetails;
+import com.moonbaar.domain.badge.dto.UserBadgeListResponse;
+import com.moonbaar.domain.badge.service.BadgeService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequestMapping("/users/me/badges")
+@RequiredArgsConstructor
+public class BadgeController {
+
+    private final BadgeService badgeService;
+
+    /**
+     * @param userDetails 로그인된 사용자
+     * @return 사용자가 보유한 배지 목록
+     */
+    @GetMapping
+    public UserBadgeListResponse findBadges(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return badgeService.findUserBadges(userDetails.getUser());
+    }
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
@@ -23,4 +23,14 @@ public class BadgeController {
         return badgeService.findUserBadges(userDetails.getUser());
     }
 
+    /**
+     * 사용자가 새로운 배지를 얻을 수 있는지 확인하고, 새로 얻은 배지 목록을 조회한다.
+     * @param userDetails 로그인된 사용자
+     * @return 새로 얻은 배지 목록
+     */
+    @PostMapping("/new")
+    public UserBadgeListResponse checkAndGrantBadges(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return badgeService.checkAndGrantUserBadges(userDetails.getUser());
+    }
+
 }

--- a/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
@@ -1,9 +1,11 @@
 package com.moonbaar.domain.badge.controller;
 
 import com.moonbaar.common.oauth.CustomUserDetails;
+import com.moonbaar.domain.badge.dto.BadgeProgressResponse;
 import com.moonbaar.domain.badge.dto.UserBadgeListResponse;
 import com.moonbaar.domain.badge.service.BadgeService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -31,6 +33,13 @@ public class BadgeController {
     @PostMapping("/new")
     public UserBadgeListResponse checkAndGrantBadges(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return badgeService.checkAndGrantUserBadges(userDetails.getUser());
+    }
+
+    @GetMapping("/next")
+    public ResponseEntity<BadgeProgressResponse> findNextBadge(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        return badgeService.findNextTargetBadge(userDetails.getUser())
+                .map(ResponseEntity::ok)
+                .orElseGet(()-> ResponseEntity.noContent().build());
     }
 
 }

--- a/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
+++ b/src/main/java/com/moonbaar/domain/badge/controller/BadgeController.java
@@ -6,7 +6,6 @@ import com.moonbaar.domain.badge.dto.BadgeProgressResponse;
 import com.moonbaar.domain.badge.dto.UserBadgeListResponse;
 import com.moonbaar.domain.badge.service.BadgeService;
 import lombok.RequiredArgsConstructor;
-import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
@@ -37,11 +36,15 @@ public class BadgeController {
         return badgeService.checkAndGrantUserBadges(userDetails.getUser());
     }
 
+    /**
+     * 진행률이 가장 높은 배지를 조회한다.
+     * @param userDetails 로그인된 사용자
+     * @return 진행률이 가장 높은 배지 정보 및 진행 정보. 없으면 null
+     */
     @GetMapping("/next")
-    public ResponseEntity<BadgeProgressResponse> findNextBadge(@AuthenticationPrincipal CustomUserDetails userDetails) {
+    public BadgeProgressResponse findNextBadge(@AuthenticationPrincipal CustomUserDetails userDetails) {
         return badgeService.findNextTargetBadge(userDetails.getUser())
-                .map(ResponseEntity::ok)
-                .orElseGet(()-> ResponseEntity.noContent().build());
+                .orElse(null);
     }
 
 }

--- a/src/main/java/com/moonbaar/domain/badge/dto/BadgeEvaluationContext.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/BadgeEvaluationContext.java
@@ -1,0 +1,34 @@
+package com.moonbaar.domain.badge.dto;
+
+import java.util.Map;
+
+/**
+ * 배지 획득 여부 판단에 필요한 데이터를 모아둔 클래스
+ * @param totalVisitCount 행사 방문 횟수
+ * @param visitedDistrictCount  방문한 구 개수
+ * @param visitCountByCategory  카테고리별 방문 횟수
+ */
+public record BadgeEvaluationContext(
+    long totalVisitCount,
+    int visitedDistrictCount,
+    Map<String, Long> visitCountByCategory
+){
+    /**
+     * @param categoryName  카테고리명
+     * @return  카테고리명에 해당하는 행사에 방문한 횟수
+     */
+    public long getVisitCountByCategoryName(String categoryName) {
+        return visitCountByCategory.getOrDefault(categoryName, 0L);
+    }
+
+    /**
+     * @param prefix 카테고리명의 시작 단어
+     * @return prefix로 카테고리명이 시작하는 행사에 방문한 횟수
+     */
+    public long getVisitCountByCategoryPrefix(String prefix) {
+        return visitCountByCategory.entrySet().stream()
+                .filter(entry -> entry.getKey().startsWith(prefix))
+                .mapToLong(Map.Entry::getValue)
+                .sum();
+    }
+}

--- a/src/main/java/com/moonbaar/domain/badge/dto/BadgeListResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/BadgeListResponse.java
@@ -1,0 +1,8 @@
+package com.moonbaar.domain.badge.dto;
+
+import java.util.List;
+
+public record BadgeListResponse(
+        List<BadgeResponse> badges
+) {
+}

--- a/src/main/java/com/moonbaar/domain/badge/dto/BadgeProgressResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/BadgeProgressResponse.java
@@ -1,5 +1,7 @@
 package com.moonbaar.domain.badge.dto;
 
+import com.moonbaar.domain.badge.entity.Badge;
+
 public record BadgeProgressResponse(
         Long id,
         String code,
@@ -8,4 +10,14 @@ public record BadgeProgressResponse(
         long progress,
         long target
 ) {
+    public static BadgeProgressResponse of(Badge badge, long progress, long target) {
+        return new BadgeProgressResponse(
+                badge.getId(),
+                badge.getCode().name(),
+                badge.getName(),
+                badge.getDescription(),
+                progress,
+                target
+        );
+    }
 }

--- a/src/main/java/com/moonbaar/domain/badge/dto/BadgeProgressResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/BadgeProgressResponse.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.badge.dto;
+
+public record BadgeProgressResponse(
+        Long id,
+        String code,
+        String name,
+        String description,
+        long progress,
+        long target
+) {
+}

--- a/src/main/java/com/moonbaar/domain/badge/dto/BadgeResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/BadgeResponse.java
@@ -1,0 +1,25 @@
+package com.moonbaar.domain.badge.dto;
+
+import com.moonbaar.domain.badge.entity.Badge;
+
+public record BadgeResponse(
+        Long id,
+        String badgeType,
+        String code,
+        String name,
+        String description,
+        String imageUrl,
+        boolean owned
+) {
+    public static BadgeResponse from(Badge badge, boolean owned) {
+        return new BadgeResponse(
+                badge.getId(),
+                badge.getBadgeType().name(),
+                badge.getCode().name(),
+                badge.getName(),
+                badge.getDescription(),
+                badge.getImageUrl(),
+                owned
+        );
+    }
+}

--- a/src/main/java/com/moonbaar/domain/badge/dto/BadgeResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/BadgeResponse.java
@@ -11,7 +11,7 @@ public record BadgeResponse(
         String imageUrl,
         boolean owned
 ) {
-    public static BadgeResponse from(Badge badge, boolean owned) {
+    public static BadgeResponse of(Badge badge, boolean owned) {
         return new BadgeResponse(
                 badge.getId(),
                 badge.getBadgeType().name(),

--- a/src/main/java/com/moonbaar/domain/badge/dto/UserBadgeListResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/UserBadgeListResponse.java
@@ -1,0 +1,16 @@
+package com.moonbaar.domain.badge.dto;
+
+import com.moonbaar.domain.badge.entity.UserBadge;
+
+import java.util.List;
+
+public record UserBadgeListResponse(
+    List<UserBadgeResponse> userBadges
+) {
+    public static UserBadgeListResponse from(List<UserBadge> userBadges) {
+        List<UserBadgeResponse> userBadgeResponses = userBadges.stream()
+                .map(UserBadgeResponse::from)
+                .toList();
+        return new UserBadgeListResponse(userBadgeResponses);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/badge/dto/UserBadgeResponse.java
+++ b/src/main/java/com/moonbaar/domain/badge/dto/UserBadgeResponse.java
@@ -1,0 +1,29 @@
+package com.moonbaar.domain.badge.dto;
+
+import com.moonbaar.domain.badge.entity.UserBadge;
+
+import java.time.LocalDateTime;
+
+public record UserBadgeResponse(
+        Long id,
+        Long badgeId,
+        String badgeType,
+        String code,
+        String name,
+        String description,
+        String imageUrl,
+        LocalDateTime createdAt
+) {
+    public static UserBadgeResponse from(UserBadge userBadge) {
+        return new UserBadgeResponse(
+                userBadge.getId(),
+                userBadge.getBadge().getId(),
+                userBadge.getBadge().getBadgeType().name(),
+                userBadge.getBadge().getCode().name(),
+                userBadge.getBadge().getName(),
+                userBadge.getBadge().getDescription(),
+                userBadge.getBadge().getImageUrl(),
+                userBadge.getCreatedAt()
+        );
+    }
+}

--- a/src/main/java/com/moonbaar/domain/badge/entity/Badge.java
+++ b/src/main/java/com/moonbaar/domain/badge/entity/Badge.java
@@ -1,0 +1,34 @@
+package com.moonbaar.domain.badge.entity;
+
+import com.moonbaar.common.entity.BaseEntityWithUpdate;
+import com.moonbaar.domain.badge.enums.BadgeCode;
+import com.moonbaar.domain.badge.enums.BadgeType;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "badges")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class Badge extends BaseEntityWithUpdate {
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "badge_type", nullable = false)
+    private BadgeType badgeType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "code", nullable = false, unique = true)
+    private BadgeCode code;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(name = "image_url")
+    private String imageUrl;
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/entity/UserBadge.java
+++ b/src/main/java/com/moonbaar/domain/badge/entity/UserBadge.java
@@ -1,0 +1,27 @@
+package com.moonbaar.domain.badge.entity;
+
+import com.moonbaar.common.entity.BaseEntity;
+import com.moonbaar.domain.user.entity.User;
+import jakarta.persistence.*;
+import lombok.*;
+
+@Entity
+@Table(name = "user_badges", uniqueConstraints = {
+        @UniqueConstraint(columnNames = {"user_id", "badge_id"})
+})
+@Getter
+@Setter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+public class UserBadge extends BaseEntity {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "badge_id", nullable = false)
+    private Badge badge;
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/enums/BadgeCode.java
+++ b/src/main/java/com/moonbaar/domain/badge/enums/BadgeCode.java
@@ -1,0 +1,81 @@
+package com.moonbaar.domain.badge.enums;
+
+import com.moonbaar.domain.badge.dto.BadgeEvaluationContext;
+import lombok.Getter;
+
+import java.util.function.Function;
+
+@Getter
+public enum BadgeCode {
+
+    FIRST_VISIT(stats -> stats.totalVisitCount(), 1),
+
+    SEOUL_EXPLORER(stats -> (long) stats.visitedDistrictCount(), 10),
+
+    SEOUL_MASTER(stats -> (long) stats.visitedDistrictCount(), 25),
+
+    CULTURE_CLASS_EXPLORER(stats -> stats.getVisitCountByCategoryName("교육/체험"), 1),
+
+    CULTURE_CLASS_MANIA(stats -> stats.getVisitCountByCategoryName("교육/체험"), 10),
+
+    KOREAN_TRADITION_EXPLORER(stats -> stats.getVisitCountByCategoryName("국악"), 1),
+
+    KOREAN_TRADITION_MANIA(stats -> stats.getVisitCountByCategoryName("국악"), 10),
+
+    SOLO_PERFORMANCE_EXPLORER(stats -> stats.getVisitCountByCategoryName("독주/독창회"), 1),
+
+    SOLO_PERFORMANCE_MANIA(stats -> stats.getVisitCountByCategoryName("독주/독창회"), 10),
+
+    MUSICAL_OPERA_EXPLORER(stats -> stats.getVisitCountByCategoryName("뮤지컬/오페라"), 1),
+
+    MUSICAL_OPERA_MANIA(stats -> stats.getVisitCountByCategoryName("뮤지컬/오페라"), 10),
+
+    DANCE_EXPLORER(stats -> stats.getVisitCountByCategoryName("무용"), 1),
+
+    DANCE_MANIA(stats -> stats.getVisitCountByCategoryName("무용"), 10),
+
+    PLAY_EXPLORER(stats -> stats.getVisitCountByCategoryName("연극"), 1),
+
+    PLAY_MANIA(stats -> stats.getVisitCountByCategoryName("연극"), 10),
+
+    MOVIE_EXPLORER(stats -> stats.getVisitCountByCategoryName("영화"), 1),
+
+    MOVIE_MANIA(stats -> stats.getVisitCountByCategoryName("영화"), 10),
+
+    EXHIBITION_ART_EXPLORER(stats -> stats.getVisitCountByCategoryName("전시/미술"), 1),
+
+    EXHIBITION_ART_MANIA(stats -> stats.getVisitCountByCategoryName("전시/미술"), 10),
+
+    FESTIVAL_EXPLORER(stats -> stats.getVisitCountByCategoryPrefix("축제"), 1),
+
+    FESTIVAL_MANIA(stats -> stats.getVisitCountByCategoryPrefix("축제"), 10),
+
+    CLASSIC_EXPLORER(stats -> stats.getVisitCountByCategoryName("클래식"), 1),
+
+    CLASSIC_MANIA(stats -> stats.getVisitCountByCategoryName("클래식"), 10),
+
+    CONCERT_EXPLORER(stats -> stats.getVisitCountByCategoryName("콘서트"), 1),
+
+    CONCERT_MANIA(stats -> stats.getVisitCountByCategoryName("콘서트"), 10),
+
+    ETC_EXPLORER(stats -> stats.getVisitCountByCategoryName("기타"), 1),
+
+    ETC_MANIA(stats -> stats.getVisitCountByCategoryName("기타"), 10);
+
+    private final Function<BadgeEvaluationContext, Long> progressExtractor;
+    private final long target;
+
+    BadgeCode(Function<BadgeEvaluationContext, Long> progressExtractor, long target) {
+        this.progressExtractor = progressExtractor;
+        this.target = target;
+    }
+
+    public long getProgress(BadgeEvaluationContext context) {
+        return progressExtractor.apply(context);
+    }
+
+    public boolean isAchieved(BadgeEvaluationContext context) {
+        return getProgress(context) >= target;
+    }
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/enums/BadgeType.java
+++ b/src/main/java/com/moonbaar/domain/badge/enums/BadgeType.java
@@ -1,0 +1,11 @@
+package com.moonbaar.domain.badge.enums;
+
+import lombok.Getter;
+
+public enum BadgeType {
+
+    VISIT_COUNT,
+    VISITED_DISTRICT_COUNT,
+    COUNT_BY_CATEGORY;
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/exception/BadgeErrorCode.java
+++ b/src/main/java/com/moonbaar/domain/badge/exception/BadgeErrorCode.java
@@ -1,0 +1,17 @@
+package com.moonbaar.domain.badge.exception;
+
+import com.moonbaar.common.exception.ErrorCode;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+
+@Getter
+@RequiredArgsConstructor
+public enum BadgeErrorCode implements ErrorCode {
+
+    BADGE_NOT_FOUND("B001", "배지 정보를 찾을 수 없습니다.", HttpStatus.NOT_FOUND);
+
+    private final String code;
+    private final String message;
+    private final HttpStatus status;
+}

--- a/src/main/java/com/moonbaar/domain/badge/exception/BadgeNotFoundException.java
+++ b/src/main/java/com/moonbaar/domain/badge/exception/BadgeNotFoundException.java
@@ -1,0 +1,9 @@
+package com.moonbaar.domain.badge.exception;
+
+import com.moonbaar.common.exception.BusinessException;
+
+public class BadgeNotFoundException extends BusinessException {
+    public BadgeNotFoundException() {
+        super(BadgeErrorCode.BADGE_NOT_FOUND);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/moonbaar/domain/badge/repository/BadgeRepository.java
@@ -4,10 +4,12 @@ import com.moonbaar.domain.badge.entity.Badge;
 import com.moonbaar.domain.badge.enums.BadgeCode;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 public interface BadgeRepository extends JpaRepository<Badge, Long> {
 
     Optional<Badge> getByCode(BadgeCode code);
 
+    List<Badge> findAllByOrderByIdAsc();
 }

--- a/src/main/java/com/moonbaar/domain/badge/repository/BadgeRepository.java
+++ b/src/main/java/com/moonbaar/domain/badge/repository/BadgeRepository.java
@@ -1,0 +1,13 @@
+package com.moonbaar.domain.badge.repository;
+
+import com.moonbaar.domain.badge.entity.Badge;
+import com.moonbaar.domain.badge.enums.BadgeCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface BadgeRepository extends JpaRepository<Badge, Long> {
+
+    Optional<Badge> getByCode(BadgeCode code);
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/moonbaar/domain/badge/repository/UserBadgeRepository.java
@@ -1,0 +1,14 @@
+package com.moonbaar.domain.badge.repository;
+
+import com.moonbaar.domain.badge.entity.UserBadge;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+
+import java.util.List;
+
+public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
+
+    @Query("SELECT ub FROM UserBadge ub JOIN FETCH ub.badge WHERE ub.user.id = :userId")
+    List<UserBadge> findByUser(Long userId);
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/moonbaar/domain/badge/repository/UserBadgeRepository.java
@@ -4,15 +4,11 @@ import com.moonbaar.domain.badge.entity.UserBadge;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
-import java.util.List;
 import java.util.Set;
 
 public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
 
-    @Query("SELECT ub FROM UserBadge ub JOIN FETCH ub.badge WHERE ub.user.id = :userId")
-    List<UserBadge> findByUser(Long userId);
-
     @Query("SELECT b.code FROM UserBadge ub JOIN ub.badge b WHERE ub.user.id = :userId")
-    Set<String> findCodeByUser(Long userId);
+    Set<String> findCodeByUserId(Long userId);
 
 }

--- a/src/main/java/com/moonbaar/domain/badge/repository/UserBadgeRepository.java
+++ b/src/main/java/com/moonbaar/domain/badge/repository/UserBadgeRepository.java
@@ -5,10 +5,14 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 
 import java.util.List;
+import java.util.Set;
 
 public interface UserBadgeRepository extends JpaRepository<UserBadge, Long> {
 
     @Query("SELECT ub FROM UserBadge ub JOIN FETCH ub.badge WHERE ub.user.id = :userId")
     List<UserBadge> findByUser(Long userId);
+
+    @Query("SELECT b.code FROM UserBadge ub JOIN ub.badge b WHERE ub.user.id = :userId")
+    Set<String> findCodeByUser(Long userId);
 
 }

--- a/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
@@ -35,7 +35,7 @@ public class BadgeService {
         List<Badge> badges = badgeRepository.findAllByOrderByIdAsc();
         Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUserId(user.getId());
         List<BadgeResponse> badgeResponses = badges.stream()
-                .map(badge -> BadgeResponse.from(
+                .map(badge -> BadgeResponse.of(
                         badge,
                         ownedBadgeCodes.contains(badge.getCode().name())
                 ))
@@ -131,17 +131,8 @@ public class BadgeService {
 
             if (progressRate > maximumProgressRate) {
                 maximumProgressRate = progressRate;
-
                 Badge badge = badgeRepository.getByCode(badgeCode).orElseThrow(BadgeNotFoundException::new);
-
-                badgeProgressResponse = new BadgeProgressResponse(
-                        badge.getId(),
-                        badge.getCode().name(),
-                        badge.getName(),
-                        badge.getDescription(),
-                        progress,
-                        target
-                );
+                badgeProgressResponse = BadgeProgressResponse.of(badge, progress, target);
             }
         }
         return Optional.ofNullable(badgeProgressResponse);

--- a/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
@@ -1,0 +1,23 @@
+package com.moonbaar.domain.badge.service;
+
+import com.moonbaar.domain.badge.dto.*;
+import com.moonbaar.domain.badge.entity.UserBadge;
+import com.moonbaar.domain.badge.repository.UserBadgeRepository;
+import com.moonbaar.domain.user.entity.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+import java.util.*;
+
+@Service
+@RequiredArgsConstructor
+public class BadgeService {
+
+    private final UserBadgeRepository userBadgeRepository;
+
+    public UserBadgeListResponse findUserBadges(User user) {
+        List<UserBadge> userBadges = userBadgeRepository.findByUser(user.getId());
+        return UserBadgeListResponse.from(userBadges);
+    }
+
+}

--- a/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
@@ -25,9 +25,22 @@ public class BadgeService {
     private final BadgeRepository badgeRepository;
     private final VisitRepository visitRepository;
 
-    public UserBadgeListResponse findUserBadges(User user) {
-        List<UserBadge> userBadges = userBadgeRepository.findByUser(user.getId());
-        return UserBadgeListResponse.from(userBadges);
+    /**
+     * 전체 배지 목록과 사용자의 소유 여부를 조회한다.
+     * @param user 로그인된 사용자
+     * @return 전체 배지 정보 및 소유 여부
+     */
+    public BadgeListResponse findUserBadges(User user) {
+        List<Badge> badges = badgeRepository.findAllByOrderByIdAsc();
+        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUser(user.getId());
+        List<BadgeResponse> badgeResponses = badges.stream()
+                .map(badge -> BadgeResponse.from(
+                        badge,
+                        ownedBadgeCodes.contains(badge.getCode().name())
+                ))
+                .toList();
+
+        return new BadgeListResponse(badgeResponses);
     }
 
     /**

--- a/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
@@ -1,23 +1,90 @@
 package com.moonbaar.domain.badge.service;
 
 import com.moonbaar.domain.badge.dto.*;
+import com.moonbaar.domain.badge.entity.Badge;
 import com.moonbaar.domain.badge.entity.UserBadge;
+import com.moonbaar.domain.badge.enums.BadgeCode;
+import com.moonbaar.domain.badge.exception.BadgeNotFoundException;
+import com.moonbaar.domain.badge.repository.BadgeRepository;
 import com.moonbaar.domain.badge.repository.UserBadgeRepository;
+import com.moonbaar.domain.statistics.dto.VisitCountByName;
 import com.moonbaar.domain.user.entity.User;
+import com.moonbaar.domain.visit.repository.VisitRepository;
+import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
 public class BadgeService {
 
     private final UserBadgeRepository userBadgeRepository;
+    private final BadgeRepository badgeRepository;
+    private final VisitRepository visitRepository;
 
     public UserBadgeListResponse findUserBadges(User user) {
         List<UserBadge> userBadges = userBadgeRepository.findByUser(user.getId());
         return UserBadgeListResponse.from(userBadges);
+    }
+
+    /**
+     * 사용자가 새롭게 얻은 배지를 저장하고 응답한다.
+     * @param user 로그인된 사용자
+     * @return 새롭게 얻은 배지 목록
+     */
+    @Transactional
+    public UserBadgeListResponse checkAndGrantUserBadges(User user) {
+        // 배지 획득 여부 판단에 필요한 데이터 계산
+        BadgeEvaluationContext badgeEvaluationContext = createBadgeEvaluationContext(user.getId());
+
+        // 기존에 소유한 배지 코드 목록
+        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUser(user.getId());
+
+        // 새롭게 얻은 배지 목록
+        List<UserBadgeResponse> newlyGrantedBadges = new ArrayList<>();
+
+        for (BadgeCode badgeCode : BadgeCode.values()) {
+            if (ownedBadgeCodes.contains(badgeCode.name())) {
+                continue; // 이미 소유한 배지는 건너뜀
+            }
+
+            // 조건을 충족한 배지 저장
+            if (badgeCode.isAchieved(badgeEvaluationContext)) {
+                Badge badge = badgeRepository.getByCode(badgeCode).orElseThrow(BadgeNotFoundException::new);
+                UserBadge userBadge = UserBadge.builder()
+                        .user(user)
+                        .badge(badge)
+                        .build();
+                userBadgeRepository.save(userBadge);
+
+                newlyGrantedBadges.add(UserBadgeResponse.from(userBadge));
+            }
+        }
+        return new UserBadgeListResponse(newlyGrantedBadges);
+    }
+
+    /**
+     * 사용자의 활동 기록을 조회하여 배지 획득 여부 판단에 필요한 데이터를 계산한다.
+     * @param userId 로그인된 사용자 아이디
+     * @return BadgeEvaluationContext 계산된 사용자 활동 데이터
+     */
+    private BadgeEvaluationContext createBadgeEvaluationContext(Long userId) {
+        long totalVisitCount = visitRepository.countByUserId(userId);
+
+        List<VisitCountByName> visitCountByDistrictNames = visitRepository.countVisitsByDistrict(userId);
+        int visitedDistrictCount = visitCountByDistrictNames.size();
+
+        List<VisitCountByName> visitCountByCategoryNames = visitRepository.countVisitsByCategory(userId);
+        Map<String, Long> visitCountByCategory = visitCountByCategoryNames.stream()
+                .collect(Collectors.toMap(
+                        VisitCountByName::name,
+                        VisitCountByName::count
+                ));
+
+        return new BadgeEvaluationContext(totalVisitCount, visitedDistrictCount, visitCountByCategory);
     }
 
 }

--- a/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
+++ b/src/main/java/com/moonbaar/domain/badge/service/BadgeService.java
@@ -10,9 +10,9 @@ import com.moonbaar.domain.badge.repository.UserBadgeRepository;
 import com.moonbaar.domain.statistics.dto.VisitCountByName;
 import com.moonbaar.domain.user.entity.User;
 import com.moonbaar.domain.visit.repository.VisitRepository;
-import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
 import java.util.stream.Collectors;
@@ -30,9 +30,10 @@ public class BadgeService {
      * @param user 로그인된 사용자
      * @return 전체 배지 정보 및 소유 여부
      */
+    @Transactional(readOnly = true)
     public BadgeListResponse findUserBadges(User user) {
         List<Badge> badges = badgeRepository.findAllByOrderByIdAsc();
-        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUser(user.getId());
+        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUserId(user.getId());
         List<BadgeResponse> badgeResponses = badges.stream()
                 .map(badge -> BadgeResponse.from(
                         badge,
@@ -54,7 +55,7 @@ public class BadgeService {
         BadgeEvaluationContext badgeEvaluationContext = createBadgeEvaluationContext(user.getId());
 
         // 기존에 소유한 배지 코드 목록
-        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUser(user.getId());
+        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUserId(user.getId());
 
         // 새롭게 얻은 배지 목록
         List<UserBadgeResponse> newlyGrantedBadges = new ArrayList<>();
@@ -105,9 +106,10 @@ public class BadgeService {
      * @param user 로그인된 사용자
      * @return 진행률이 가장 높은 배지 정보 및 진행 정보
      */
+    @Transactional(readOnly = true)
     public Optional<BadgeProgressResponse> findNextTargetBadge(User user) {
         BadgeEvaluationContext badgeEvaluationContext = createBadgeEvaluationContext(user.getId());
-        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUser(user.getId());
+        Set<String> ownedBadgeCodes = userBadgeRepository.findCodeByUserId(user.getId());
 
         BadgeProgressResponse badgeProgressResponse = null;
         double maximumProgressRate = 0.0;


### PR DESCRIPTION
## 이슈
- #41 

## 주요 변경 사항
> 소유 배지/다음 목표 조회 및 배지 획득 처리 기능 구현

1. Badge 엔티티와 UserBadge 엔티티를 구현했습니다. 

2. 사용자가 소유한 배지를 조회하는 `GET /users/me/badges` 엔드포인트를 구현했습니다.

3. 사용자가 얻을 수 있는 배지를 찾아 획득 처리하고, 새롭게 획득한 배지를 응답하는 `POST /users/me/badges/new` 엔드포인트를 구현했습니다.

4. 사용자의 다음 목표 배지를 조회하는 `GET /users/me/badges/next` 엔드포인트를 구현했습니다.

## 세부 설명

### 배지 획득 처리 전략
배지 획득의 기준이 되는 요소는 `조건`과 `값`입니다.
회의에서 '현재 배지 개수는 27개로 많지 않기 때문에 Java 코드 상에서 검증하자'는 결론을 내렸습니다.

**구현한 구체적인 방법**

1. 자바 코드에서 조건과 값 관리

배지마다 고유한 code를 BadgeCode enum으로 만들어서 `조건`과, `값`을 각각 작성하였습니다.
```Java
public enum BadgeCode {

    FIRST_VISIT(stats -> stats.totalVisitCount(), 1),
    SEOUL_EXPLORER(stats -> (long) stats.visitedDistrictCount(), 10),
    SEOUL_MASTER(stats -> (long) stats.visitedDistrictCount(), 25),
    CULTURE_CLASS_EXPLORER(stats -> stats.getVisitCountByCategoryName("교육/체험"), 1),
    ...

    private final Function<BadgeEvaluationContext, Long> progressExtractor;
    private final long target;
```

2. 즉시 계산

FE에서 '새로운 배지 획득 확인 요청'을 보내면 BE는 사용자의 방문 데이터를 바탕으로 조건식에 필요한 데이터를 계산합니다.
``` Java
/**
 * 배지 획득 여부 판단에 필요한 데이터를 모아둔 클래스
 * @param totalVisitCount 행사 방문 횟수
 * @param visitedDistrictCount  방문한 구 개수
 * @param visitCountByCategory  카테고리별 방문 횟수
 */
public record BadgeEvaluationContext(
    long totalVisitCount,
    int visitedDistrictCount,
    Map<String, Long> visitCountByCategory
)
```
이렇게 만들어진 데이터는 BadgeCode의 조건(progressExtractor)이 목표(target)을 넘는지 확인하는데서 활용됩니다.
> 현재는 progress >= target 이외의 조건식이 없기 때문에 현재와 같은 방식으로 구현했지만 새로운 유형의 조건식이 생긴다면 로직이 크게 변경될 우려가 있습니다.

3. DB 저장 및 응답

계산된 데이터로 사용자가 현재 소유하지 않은 배지 중에 조건을 달성한 배지가 있는지 확인하고, 조건을 달성했다면 새로운 배지를 저장하고 응답하게 됩니다.

**확장 방향**
새로운 배지가 추가되는 상황을 고려하여 다음과 같은 확장 방향성을 고려하였습니다.

1. `값`은 다르지만 `조건`이 같은 배지를 동일한 BadgeType으로 관리합니다. 
- 이에 맞춰 현재는 BadgeType을 `VISIT_COUNT`, `VISITED_DISTRICT_COUNT`, `COUNT_BY_CATEGORY` 3개로 구성하였습니다.

2. BadgeCode 대신 BadgeType에서 조건을 관리합니다.
- 값은 DB에서 관리합니다.
> 단, 추가적으로 DB에 저장된 값을 파싱하는 방법을 BadgeType에서 조건처럼 관리해줘야 합니다. 예를 들어, 첫 방문 배지는 한 개의 값만 필요하지만, 카테고리별 탐험가/마니아 배지의 경우 '카테고리 명'과 '횟수' 두 가지의 값이 필요하기 때문에 이를 구분해 주는 것이 필요합니다.

이렇게 확장하였을 때 장점은 27개의 BadgeCode를 enum으로 관리하지 않고, 3개의 BadgeType enum으로 관리 할 수 있습니다.

**고려 사항**
1. 배지 검증 시점
현재는 방문 인증이 발생한 이후에만 새로운 배지를 검증해도 문제가 없습니다.
하지만 다른 종류의 이벤트 (ex 찜하기, 출석 등)가 생기면 방문 인증 로직 안에서 배지를 검증하는 것은 좋지 않은 구조인 것 같아서 우선 방문 로직과 분리를 하였습니다.
그리고 FE가요청할 때만 응답할지, BE에서 먼저 알려줄지 고민해 보았으나 현재 단계에서는 FE가 요청하는 것으로 구현을 하였습니다.
> 추가로 BE는 '방문 인증 로직에 포함/배치' 등을 통해 미리 배지를 저장해두고, FE가 요청하면 새로운 배지 목록을 조회만 하는 방법도 있습니다. (기존 명세서 방법) 배치 작업과 DB 테이블 변경(어디까지 알려줬는지 저장해야함)이 필요하여 보류하였습니다.

> 정리
> - FE 요청 -> 배지 저장 -> 응답 (현재 방법)
> - 배지 작업으로 배지 저장-> BE에서 SSE/WebSocket 으로 데이터 전송
> - 배치 작업으로 배지 저장 -> FE 요청 -> 응답

2. 자바 코드와 DB의 일치
현재 DB에는 INSERT 문으로 데이터를 저장하였고, 저장된 code를 참고하여 BadgeCode enum을 만들어 둔 상태입니다. 이러한 방식은 불일치가 발생할 수 있습니다. (ex 오타, DB에서 삭제됨) 이러한 불일치로 문제가 발생하지 않도록 처리하는 로직이 필요합니다.

3. `BadgeEvaluationContext` 계산 시점
현재는 요청이 올 때마다 계산을 하고 있지만, redis 등을 활용하여 캐싱할 수 있습니다.

### Predicate와 Function 활용
`Predicate`는 자바에서 "어떤 값을 받아서 true 또는 false를 반환하는 함수형 인터페이스" 입니다.
```Java
@FunctionalInterface
public interface Predicate<T> {
    boolean test(T t);
}
```
처음에 `Predicate`를 활용해서 검증을 하였습니다.
```
if (badgeCode.getCondition().test(badgeEvaluationContext)) {...}
```

`Predicate`를 사용하지 않았을 때
```Java
public enum BadgeCode {
    FIRST_VISIT(1),
    FIVE_VISITS(5),
    TEN_VISITS(10);

    private final long target;
}
```
```Java
boolean granted = false;
    switch (badgeCode) {
        case FIRST_VISIT:
            granted = badgeEvaluationContext.getTotalVisitCount() >= 1;
            break;
        ...
    }
```
`Predicate`를 사용하는 것이 훨씬 깔끔한 로직이 됩니다.
조건을 검사할 때 사용하면 좋은 것 같아 공유합니다.

---

이후 단순이 조건 T/F 확인이 아닌 다음 목표 조회 기능에 현재 진행도가 필요해서
`Function<T, R>`로 바꾸게 되었습니다.
`Function<T, R>`은 "T 타입을 받아서 R 타입을 리턴하는 함수형 인터페이스"입니다.

```Java
@FunctionalInterface
public interface Function<T, R> {
    R apply(T t);
}
```

예를 들어서
`CONCERT_EXPLORER(stats -> stats.getVisitCountByCategoryName("콘서트"), 1)`
의 경우 `BadgeEvaluationContext`를 입력받아서 `getVisitCountByCategoryName(카테고리명)`을 수행한 결과를 리턴합니다.

즉 `Function`의 `apply`를 하게 되면 `BadgeEvaluationContext `에서 '콘서트' 카테고리의 방문 횟수를 확인 할 수 있습니다.

```Java
// BadgeCode
public long getProgress(BadgeEvaluationContext context) {
        return progressExtractor.apply(context);
}

// BadgeEvaluationContext 
public long getVisitCountByCategoryName(String categoryName) {
        return visitCountByCategory.getOrDefault(categoryName, 0L);
}
```
따라서 다음과 같은 계산에 활용됩니다.
- 배지 획득 여부 : progress >= target (T/F만 알면됨)
- 다음 목표 : progress / target (progress 값 필요함)


## 다음 작업
- 테스트 코드 작성
- BadgeCode enum과 DB 데이터 불일치에 관한 처리