### PR TITLE
feat: 프론트엔드 배포 서버 allowed origins 추가

### DIFF
--- a/src/main/java/com/moonbaar/common/config/CorsProperties.java
+++ b/src/main/java/com/moonbaar/common/config/CorsProperties.java
@@ -1,0 +1,17 @@
+package com.moonbaar.common.config;
+
+import java.util.ArrayList;
+import java.util.List;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.stereotype.Component;
+
+@Getter
+@Setter
+@Component
+@ConfigurationProperties(prefix = "cors")
+public class CorsProperties {
+
+    private List<String> allowedOrigins = new ArrayList<>();
+}

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -62,7 +62,10 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedOrigins(Arrays.asList(
+                "http://localhost:3000",
+                "https://moonbaar.netlify.app"
+        ));
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("authorization", "content-type", "x-auth-token"));
         configuration.setExposedHeaders(Arrays.asList("x-auth-token"));

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.moonbaar.common.config;
 import com.moonbaar.common.filter.JwtAuthenticationFilter;
 import com.moonbaar.common.oauth.handler.OAuth2SuccessHandler;
 import jakarta.servlet.http.HttpServletResponse;
+import java.util.Arrays;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -17,13 +18,12 @@ import org.springframework.web.cors.CorsConfiguration;
 import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
-import java.util.Arrays;
-
 @Configuration
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
 
+    private final CorsProperties corsProperties;
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
@@ -62,10 +62,7 @@ public class SecurityConfig {
     @Bean
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
-        configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:3000",
-                "https://moonbaar.netlify.app"
-        ));
+        configuration.setAllowedOrigins(corsProperties.getAllowedOrigins());
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"));
         configuration.setAllowedHeaders(Arrays.asList("authorization", "content-type", "x-auth-token"));
         configuration.setExposedHeaders(Arrays.asList("x-auth-token"));

--- a/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
@@ -26,6 +26,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
 
+    @Value("${frontend.redirect-url}")
+    private String redirectUrl;
+
     @Value("${jwt.access-token-expiration}")
     private long accessTokenExpirationMs;
 
@@ -67,10 +70,6 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessCookie);
         response.addCookie(refreshCookie);
 
-        // Origin이 허용된 경우에만 리디렉트
-        String origin = request.getHeader("Origin");
-        if (origin != null && corsProperties.getAllowedOrigins().contains(origin)) {
-            response.sendRedirect(origin + "/login-success");
-        }
+        response.sendRedirect(redirectUrl);
     }
 }

--- a/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
@@ -1,5 +1,6 @@
 package com.moonbaar.common.oauth.handler;
 
+import com.moonbaar.common.config.CorsProperties;
 import com.moonbaar.common.oauth.CustomOAuth2User;
 import com.moonbaar.common.utils.JwtUtils;
 import com.moonbaar.domain.user.entity.User;
@@ -21,11 +22,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
+    private final CorsProperties corsProperties;
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
-
-    @Value("${frontend.redirect-url}")
-    private String redirectUrl;
 
     @Value("${jwt.access-token-expiration}")
     private long accessTokenExpirationMs;
@@ -68,6 +67,10 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessCookie);
         response.addCookie(refreshCookie);
 
-        response.sendRedirect(redirectUrl + "/login-success");
+        // Origin이 허용된 경우에만 리디렉트
+        String origin = request.getHeader("Origin");
+        if (origin != null && corsProperties.getAllowedOrigins().contains(origin)) {
+            response.sendRedirect(origin + "/login-success");
+        }
     }
 }


### PR DESCRIPTION
## 1
~~프론트엔드 배포 서버와 localhost url을 동적으로 redirect url에 설정해주기 위해
request의 origin을 확인하여 redirect url을 생성하도록 했습니다.~~

<img width="564" alt="image" src="https://github.com/user-attachments/assets/832e2b7a-eff2-4771-bd1f-8c0cc98dcfae" />


->

oauth2 인증의 경우 클라이언트의 리퀘스트가 oauth2 provider의 url을 거쳐 백엔드로 오게 됩니다.
이 경우 클라이언트가 보낸 request의 origin, referer가 사라지게 되어
위에서 의도했던 대로 redirect url이 생성되지 않았습니다.

때문에 다시 application.yml에 고정된 값으로 미리 선언하고
해당 url을 사용하도록 했습니다.

<img width="416" alt="image" src="https://github.com/user-attachments/assets/f1932c49-fbbb-4a34-8f9f-80dfe60b90b5" />

<img width="503" alt="image" src="https://github.com/user-attachments/assets/596a8dbf-2143-40a4-b13c-6bdd21cf4ea2" />




## 2
허용된 url을 application.yml로 추출했습니다.
리스트로 사용하기 위해 `@Value`가 아닌 `CorsProperties` 컴포넌트를 만들어 사용했습니다.

<img width="497" alt="image" src="https://github.com/user-attachments/assets/7b287102-17b4-47b9-ab49-477e6045815d" />

## 3
cors의 setAllowedOrigins을 `CorsProperties`를 사용하도록 했습니다.

<img width="573" alt="image" src="https://github.com/user-attachments/assets/cb17ce24-2ea5-4c0b-aa59-672d8e916a0a" />
