### PR TITLE
feat: 행사 상세 조회 응답에 방문 횟수, 좋아요 횟수 포함

### DIFF
--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -27,11 +27,13 @@ public record EventDetailResponse(
         String hmpgAddr,
         BigDecimal latitude,
         BigDecimal longitude,
+        boolean isVisited,
         boolean isLiked,
-        boolean isVisited
+        long visitCount,
+        long likeCount
 ) {
 
-    public static EventDetailResponse of(CulturalEvent event, boolean isLiked, boolean isVisited) {
+    public static EventDetailResponse of(CulturalEvent event, boolean isVisited, boolean isLiked, long visitCount, long likeCount) {
         String categoryName = Optional.ofNullable(event.getCategory())
                 .map(Category::getName)
                 .orElse(null);
@@ -62,8 +64,10 @@ public record EventDetailResponse(
                 event.getHmpgAddr(),
                 event.getLatitude(),
                 event.getLongitude(),
+                isVisited,
                 isLiked,
-                isVisited
+                visitCount,
+                likeCount
         );
     }
 }

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -60,15 +60,20 @@ public class EventService {
 
     public EventDetailResponse getEventDetail(Long eventId) {
         CulturalEvent event = eventProvider.getEventById(eventId);
-        return EventDetailResponse.of(event, false, false);
+        long visitCount = visitRepository.countByEventId(eventId);
+        long likeCount = likedEventRepository.countByEventId(eventId);
+
+        return EventDetailResponse.of(event, false, false, visitCount, likeCount);
     }
 
     public EventDetailResponse getEventDetailForUser(User user, Long eventId) {
         CulturalEvent event = eventProvider.getEventById(eventId);
+        long visitCount = visitRepository.countByEventId(eventId);
+        long likeCount = likedEventRepository.countByEventId(eventId);
 
-        boolean isLiked = checkIfEventIsLiked(user, event);
         boolean isVisited = checkIfEventIsVisited(user, event);
-        return EventDetailResponse.of(event, isLiked, isVisited);
+        boolean isLiked = checkIfEventIsLiked(user, event);
+        return EventDetailResponse.of(event, isVisited, isLiked, visitCount, likeCount);
     }
 
     private boolean checkIfEventIsLiked(User user, CulturalEvent event) {

--- a/src/main/java/com/moonbaar/domain/like/repository/LikedEventRepository.java
+++ b/src/main/java/com/moonbaar/domain/like/repository/LikedEventRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface LikedEventRepository extends JpaRepository<LikedEvent, Long> {
 
@@ -17,4 +18,7 @@ public interface LikedEventRepository extends JpaRepository<LikedEvent, Long> {
 
   @Query("SELECT l FROM LikedEvent l JOIN FETCH l.event WHERE l.user = :user")
   Page<LikedEvent> findByUser(User user, Pageable pageable);
+
+  @Query("SELECT COUNT(l) FROM LikedEvent l WHERE l.event.id = :eventId")
+  long countByEventId(@Param("eventId") Long eventId);
 }

--- a/src/main/java/com/moonbaar/domain/visit/repository/VisitRepository.java
+++ b/src/main/java/com/moonbaar/domain/visit/repository/VisitRepository.java
@@ -41,6 +41,9 @@ public interface VisitRepository extends JpaRepository<Visit, Long> {
             @Param("minLng") BigDecimal minLng,
             @Param("maxLng") BigDecimal maxLng);
 
+    @Query("SELECT COUNT(v) FROM Visit v WHERE v.event.id = :eventId")
+    long countByEventId(@Param("eventId") Long eventId);
+
     @Query("SELECT COUNT(v) FROM Visit v WHERE v.user.id = :userId")
     long countByUserId(@Param("userId") Long userId);
 

--- a/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
@@ -12,6 +12,8 @@ import com.moonbaar.domain.event.entity.CulturalEvent;
 import com.moonbaar.domain.event.exeption.EventErrorCode;
 import com.moonbaar.domain.event.exeption.EventNotFoundException;
 import com.moonbaar.domain.event.repository.CulturalEventRepository;
+import com.moonbaar.domain.like.repository.LikedEventRepository;
+import com.moonbaar.domain.visit.repository.VisitRepository;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.BeforeEach;
@@ -28,6 +30,12 @@ class EventServiceTest {
 
     @Mock
     private CulturalEventRepository eventRepository;
+
+    @Mock
+    private VisitRepository visitRepository;
+
+    @Mock
+    private LikedEventRepository likedEventRepository;
 
     @Mock
     private EventProvider eventProvider;


### PR DESCRIPTION
## 이슈
- #61 

## 세부 설명
<img width="251" alt="Image" src="https://github.com/user-attachments/assets/bf7dc987-f1d4-4483-8c46-05cc07a2c09d" />

행사 상세조회 응답에 visitCount, likeCount 필드를 추가했습니다.

자잘한 변경) 기존 응답이 isLiked, isVisited 순으로 작성됐는데 이를 isVisited, isLiked, visitCount, likeCount 순서로 변경했습니다


### api 명세
|항목 | 내용|
|-- | --|
엔드포인트 | /events/{eventId}
메서드 | GET
설명 | 특정 문화행사의 상세 정보 조회
URL 파라미터 | eventId: 행사 ID
인증 | 선택사항 (인증 시 isLiked/isVisited 실제 값으로 포함)
응답 | { "id": "이벤트ID", "title": "행사명", "category": "카테고리", "district": "행정구역", "place": "장소명", "startDate": "2025-04-10T10:00:00Z", "endDate": "2025-04-10T18:00:00Z", "isFree": true, "useFee": "요금 정보", "useTarget": "이용대상", "program": "프로그램 소개", "etcDesc": "상세 설명", "mainImg": "이미지URL", "orgName": "주최자명", "orgLink": "기관 URL", "hmpgAddr": "홈페이지 주소", "latitude": 37.5665, "longitude": 126.9780, "isVisited": false, "isLiked": false, "visitCount": 42, "likeCount": 18 }
오류 코드 | 404: 행사 정보 없음

