### PR TITLE
fix: 방문 목록 응답 필드 수정

### DIFF
--- a/src/main/java/com/moonbaar/domain/visit/dto/VisitItemResponse.java
+++ b/src/main/java/com/moonbaar/domain/visit/dto/VisitItemResponse.java
@@ -6,7 +6,6 @@ import java.util.List;
 
 public record VisitItemResponse(
         Long id,
-        Long eventId,
         String title,
         String place,
         String mainImg,
@@ -15,7 +14,6 @@ public record VisitItemResponse(
 
     public static VisitItemResponse from(Visit visit) {
         return new VisitItemResponse(
-                visit.getId(),
                 visit.getEvent().getId(),
                 visit.getEvent().getTitle(),
                 visit.getEvent().getPlace(),

--- a/src/test/java/com/moonbaar/domain/visit/controller/UserVisitControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/visit/controller/UserVisitControllerTest.java
@@ -45,11 +45,11 @@ public class UserVisitControllerTest {
         // given
         LocalDateTime now = LocalDateTime.now();
         VisitItemResponse visit1 = new VisitItemResponse(
-                1L, 1L, "서울시극단 [코믹]", "세종M씨어터",
+                1L, "서울시극단 [코믹]", "세종M씨어터",
                 "https://example.com/image1.jpg", now.minusDays(3));
 
         VisitItemResponse visit2 = new VisitItemResponse(
-                2L, 2L, "노원문화예술회관 국악예술단 정기공연", "노원문화예술회관 대공연장",
+                2L, "노원문화예술회관 국악예술단 정기공연", "노원문화예술회관 대공연장",
                 "https://example.com/image2.jpg", now.minusDays(7));
 
         VisitListResponse response = new VisitListResponse(2L, 1, 1, List.of(visit1, visit2));


### PR DESCRIPTION
api 명세에 따르면 방문 목록 응답에는 방문 ID가 아닌 행사 ID만 있어야 합니다.
현재는 방문 ID를 `id` 필드로 반환하고, 행사 ID는 `eventId`로 따로 반환하고 있어
이를 명세에 맞게 수정했습니다.