### PR TITLE
feat: 사용자별 이벤트 상태 정보 조회 API 구현

### DIFF
--- a/src/main/java/com/moonbaar/domain/event/controller/EventController.java
+++ b/src/main/java/com/moonbaar/domain/event/controller/EventController.java
@@ -5,6 +5,7 @@ import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.service.EventService;
+import com.moonbaar.domain.event.dto.EventUserStatusResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -32,9 +33,14 @@ public class EventController {
             @PathVariable Long eventId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        if (userDetails == null) {
             return eventService.getEventDetail(eventId);
-        }
-        return eventService.getEventDetailForUser(userDetails.getUser(), eventId);
+    }
+
+    @GetMapping("/{eventId}/user-status")
+    public EventUserStatusResponse getEventStatus(
+            @PathVariable Long eventId,
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+
+        return eventService.getUserEventStatus(userDetails.getUser(), eventId);
     }
 }

--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -27,13 +27,11 @@ public record EventDetailResponse(
         String hmpgAddr,
         BigDecimal latitude,
         BigDecimal longitude,
-        boolean isVisited,
-        boolean isLiked,
         long visitCount,
         long likeCount
 ) {
 
-    public static EventDetailResponse of(CulturalEvent event, boolean isVisited, boolean isLiked, long visitCount, long likeCount) {
+    public static EventDetailResponse of(CulturalEvent event, long visitCount, long likeCount) {
         String categoryName = Optional.ofNullable(event.getCategory())
                 .map(Category::getName)
                 .orElse(null);
@@ -64,8 +62,6 @@ public record EventDetailResponse(
                 event.getHmpgAddr(),
                 event.getLatitude(),
                 event.getLongitude(),
-                isVisited,
-                isLiked,
                 visitCount,
                 likeCount
         );

--- a/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
@@ -19,8 +19,7 @@ public record EventSummaryResponse(
         boolean isFree,
         String mainImg,
         BigDecimal latitude,
-        BigDecimal longitude,
-        boolean isVisited
+        BigDecimal longitude
 ) {
 
     public static EventSummaryResponse from(CulturalEvent event) {
@@ -37,8 +36,7 @@ public record EventSummaryResponse(
                 isFreeEvent,
                 event.getMainImg(),
                 event.getLatitude(),
-                event.getLongitude(),
-                false
+                event.getLongitude()
         );
     }
 

--- a/src/main/java/com/moonbaar/domain/event/dto/EventUserStatusResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventUserStatusResponse.java
@@ -1,0 +1,15 @@
+package com.moonbaar.domain.event.dto;
+
+public record EventUserStatusResponse(
+        Long eventId,
+        boolean isVisited,
+        boolean isLiked
+) {
+
+    public static EventUserStatusResponse of(
+            Long eventId,
+            boolean isVisited,
+            boolean isLiked) {
+        return new EventUserStatusResponse(eventId, isVisited, isLiked);
+    }
+}

--- a/src/main/java/com/moonbaar/domain/event/service/EventService.java
+++ b/src/main/java/com/moonbaar/domain/event/service/EventService.java
@@ -8,6 +8,7 @@ import com.moonbaar.domain.event.entity.CulturalEvent;
 import com.moonbaar.domain.event.repository.CulturalEventRepository;
 import com.moonbaar.domain.event.repository.CulturalEventSpecifications;
 import com.moonbaar.domain.like.repository.LikedEventRepository;
+import com.moonbaar.domain.event.dto.EventUserStatusResponse;
 import com.moonbaar.domain.user.entity.User;
 import com.moonbaar.domain.visit.repository.VisitRepository;
 import java.util.List;
@@ -63,30 +64,16 @@ public class EventService {
         long visitCount = visitRepository.countByEventId(eventId);
         long likeCount = likedEventRepository.countByEventId(eventId);
 
-        return EventDetailResponse.of(event, false, false, visitCount, likeCount);
+        return EventDetailResponse.of(event, visitCount, likeCount);
     }
 
-    public EventDetailResponse getEventDetailForUser(User user, Long eventId) {
+    public EventUserStatusResponse getUserEventStatus(User user, Long eventId) {
         CulturalEvent event = eventProvider.getEventById(eventId);
-        long visitCount = visitRepository.countByEventId(eventId);
-        long likeCount = likedEventRepository.countByEventId(eventId);
 
-        boolean isVisited = checkIfEventIsVisited(user, event);
-        boolean isLiked = checkIfEventIsLiked(user, event);
-        return EventDetailResponse.of(event, isVisited, isLiked, visitCount, likeCount);
-    }
-
-    private boolean checkIfEventIsLiked(User user, CulturalEvent event) {
-        if (user == null) {
-            return false;
-        }
-        return likedEventRepository.existsByUserAndEvent(user, event);
-    }
-
-    private boolean checkIfEventIsVisited(User user, CulturalEvent event) {
-        if (user == null) {
-            return false;
-        }
-        return visitRepository.existsByUserAndEvent(user, event);
+        return EventUserStatusResponse.of(
+                event.getId(),
+                visitRepository.existsByUserAndEvent(user, event),
+                likedEventRepository.existsByUserAndEvent(user, event)
+        );
     }
 }

--- a/src/test/java/com/moonbaar/domain/event/controller/EventControllerTest.java
+++ b/src/test/java/com/moonbaar/domain/event/controller/EventControllerTest.java
@@ -1,19 +1,15 @@
 package com.moonbaar.domain.event.controller;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.moonbaar.common.config.SecurityTestConfig;
-import com.moonbaar.common.security.WithMockCustomUser;
 import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.exeption.EventErrorCode;
 import com.moonbaar.domain.event.exeption.EventNotFoundException;
 import com.moonbaar.domain.event.service.EventService;
-import com.moonbaar.domain.user.entity.User;
 import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import org.junit.jupiter.api.DisplayName;
@@ -40,7 +36,7 @@ class EventControllerTest {
     private final Long MOCK_USER_ID = 1L;
     private final Long EVENT_ID = 1L;
 
-    private EventDetailResponse createMockResponse(boolean isVisited, boolean isLiked, long visitCount, long likeCount) {
+    private EventDetailResponse createMockResponse(long visitCount, long likeCount) {
         LocalDateTime startDate = LocalDateTime.now().plusDays(1);
         LocalDateTime endDate = LocalDateTime.now().plusDays(3);
 
@@ -64,18 +60,16 @@ class EventControllerTest {
                 "https://www.seoulevent.or.kr",
                 new BigDecimal("37.5725"),
                 new BigDecimal("126.9760"),
-                isVisited,
-                isLiked,
                 visitCount,
                 likeCount
         );
     }
 
     @Test
-    @DisplayName("비로그인 사용자도 행사 상세 정보를 조회할 수 있다")
+    @DisplayName("행사 상세 정보를 조회할 수 있다")
     void getEventDetail_NonAuthenticatedUser() throws Exception {
         // given
-        when(eventService.getEventDetail(EVENT_ID)).thenReturn(createMockResponse(false, false, 1, 100));
+        when(eventService.getEventDetail(EVENT_ID)).thenReturn(createMockResponse(1, 100));
 
         // when & then
         mockMvc.perform(get("/events/{eventId}", EVENT_ID)
@@ -83,27 +77,6 @@ class EventControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.id").value(EVENT_ID.intValue()))
                 .andExpect(jsonPath("$.title").value("서울시극단 [코믹]"))
-                .andExpect(jsonPath("$.isVisited").value(false))
-                .andExpect(jsonPath("$.isLiked").value(false))
-                .andExpect(jsonPath("$.visitCount").value(1))
-                .andExpect(jsonPath("$.likeCount").value(100));
-    }
-
-    @Test
-    @DisplayName("로그인한 사용자는 좋아요/방문 상태가 포함된 행사 상세 정보를 조회할 수 있다")
-    @WithMockCustomUser
-    void getEventDetail_AuthenticatedUser() throws Exception {
-        // given
-        when(eventService.getEventDetailForUser(any(User.class), eq(EVENT_ID)))
-                .thenReturn(createMockResponse(true, false, 1, 100));
-
-        // when & then
-        mockMvc.perform(get("/events/{eventId}", EVENT_ID))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.id").value(EVENT_ID.intValue()))
-                .andExpect(jsonPath("$.title").value("서울시극단 [코믹]"))
-                .andExpect(jsonPath("$.isVisited").value(true))
-                .andExpect(jsonPath("$.isLiked").value(false))
                 .andExpect(jsonPath("$.visitCount").value(1))
                 .andExpect(jsonPath("$.likeCount").value(100));
     }


### PR DESCRIPTION
## 설명
행사 상세 정보와 관련 사용자 정보(좋아요/방문 여부)를 분리된 API로 제공하는 방식으로 변경했습니다.

## 변경 이유
처음에는 단일 엔드포인트(/events/{eventId})에서 인증 여부에 따라 다른 응답을 제공하려 했으나, 다음과 같은 문제가 있었습니다:

인증 필터 문제: JWT 필터에서 해당 경로를 인증 대상에서 제외하면(shouldNotFilter), 쿠키에 유효한 액세스 토큰이 있어도 인증 정보가 설정되지 않음
인증 강제 문제: 반대로 JWT 필터가 해당 경로를 검사하면, 토큰 없는 요청에 대해 401 오류가 발생하여 비인증 사용자는 기본 정보조차 볼 수 없음

이러한 문제들로 인해 API를 명확히 분리하는 것이 적합하다는 결론에 도달했습니다:

/events/{eventId} - 모든 사용자가 접근 가능한 기본 정보 제공 API
/events/{eventId}/user-status - 인증된 사용자의 상태 정보 제공 API

## API 명세
|항목 | 내용|
|-- | --|
엔드포인트 | /events/{eventId}/users-status
메서드 | GET
설명 | 특정 문화행사의 사용자 관련 정보
URL 파라미터 | eventId: 행사 ID
인증 | 인증 필요
응답 | { "eventId": "이벤트ID", "isVisited": "방문 여부", "isLiked": "좋아요 여부" }
오류 코드 | 404: 행사 정보 없음

