### PR TITLE
feat: 유저 정보를 포함하는 행사 목록 조회, 행사 상세 정보 조회 엔드포인트 추가

### DIFF
--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -34,7 +34,7 @@ public class SecurityConfig {
                 .cors(cors -> cors.configurationSource(corsConfigurationSource()))
                 .csrf(csrf -> csrf.disable())
                 .authorizeHttpRequests(auth -> auth
-                        .requestMatchers("/events/*/like", "/events/*/visit").authenticated()
+                        .requestMatchers("/events/*/like", "/events/*/visit", "/events/with-status/**").authenticated()
                         .requestMatchers("/login", "/oauth2/**", "/events/**", "/categories/**", "/districts/**", "/users/refresh").permitAll()  // 공개 API 경로
                         .anyRequest().authenticated()  // 나머지 경로는 인증 필요
                 )

--- a/src/main/java/com/moonbaar/domain/event/controller/EventController.java
+++ b/src/main/java/com/moonbaar/domain/event/controller/EventController.java
@@ -5,7 +5,6 @@ import com.moonbaar.domain.event.dto.EventDetailResponse;
 import com.moonbaar.domain.event.dto.EventListResponse;
 import com.moonbaar.domain.event.dto.EventSearchRequest;
 import com.moonbaar.domain.event.service.EventService;
-import com.moonbaar.domain.event.dto.EventUserStatusResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -24,23 +23,31 @@ public class EventController {
     private final EventService eventService;
 
     @GetMapping
-    public EventListResponse searchEvents(@ModelAttribute @Valid EventSearchRequest request) {
+    public EventListResponse searchEvents(
+            @ModelAttribute @Valid EventSearchRequest request) {
+
         return eventService.searchEvents(request);
     }
 
-    @GetMapping("/{eventId}")
-    public EventDetailResponse getEventDetail(
-            @PathVariable Long eventId,
+    @GetMapping("/with-status")
+    public EventListResponse searchEventsWithUserStatus(
+            @ModelAttribute @Valid EventSearchRequest request,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-            return eventService.getEventDetail(eventId);
+        return eventService.searchEventsWithUserStatus(userDetails.getUser(), request);
     }
 
-    @GetMapping("/{eventId}/user-status")
-    public EventUserStatusResponse getEventStatus(
+    @GetMapping("/{eventId}")
+    public EventDetailResponse getEventDetail(@PathVariable Long eventId) {
+
+        return eventService.getEventDetail(eventId);
+    }
+
+    @GetMapping("/with-status/{eventId}")
+    public EventDetailResponse getEventDetailWithUserStatus(
             @PathVariable Long eventId,
             @AuthenticationPrincipal CustomUserDetails userDetails) {
 
-        return eventService.getUserEventStatus(userDetails.getUser(), eventId);
+        return eventService.getEventDetailWithUserStatus(userDetails.getUser(), eventId);
     }
 }

--- a/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventDetailResponse.java
@@ -28,10 +28,12 @@ public record EventDetailResponse(
         BigDecimal latitude,
         BigDecimal longitude,
         long visitCount,
-        long likeCount
+        long likeCount,
+        boolean isVisited,
+        boolean isLiked
 ) {
 
-    public static EventDetailResponse of(CulturalEvent event, long visitCount, long likeCount) {
+    public static EventDetailResponse of(CulturalEvent event, long visitCount, long likeCount, boolean isVisited, boolean isLiked) {
         String categoryName = Optional.ofNullable(event.getCategory())
                 .map(Category::getName)
                 .orElse(null);
@@ -63,7 +65,9 @@ public record EventDetailResponse(
                 event.getLatitude(),
                 event.getLongitude(),
                 visitCount,
-                likeCount
+                likeCount,
+                isVisited,
+                isLiked
         );
     }
 }

--- a/src/main/java/com/moonbaar/domain/event/dto/EventListResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventListResponse.java
@@ -19,4 +19,18 @@ public record EventListResponse(
                 EventSummaryResponse.fromList(eventsPage.getContent())
         );
     }
+
+    public static EventListResponse fromWithVisitStatus(
+            Page<CulturalEvent> eventsPage,
+            List<Long> visitedEventIds) {
+
+        return new EventListResponse(
+                eventsPage.getTotalElements(),
+                eventsPage.getTotalPages(),
+                eventsPage.getNumber() + 1,
+                EventSummaryResponse.fromListWithVisitStatus(
+                        eventsPage.getContent(),
+                        visitedEventIds)
+        );
+    }
 }

--- a/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
+++ b/src/main/java/com/moonbaar/domain/event/dto/EventSummaryResponse.java
@@ -3,7 +3,6 @@ package com.moonbaar.domain.event.dto;
 import com.moonbaar.domain.category.entity.Category;
 import com.moonbaar.domain.district.entity.District;
 import com.moonbaar.domain.event.entity.CulturalEvent;
-import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -18,11 +17,14 @@ public record EventSummaryResponse(
         LocalDateTime endDate,
         boolean isFree,
         String mainImg,
-        BigDecimal latitude,
-        BigDecimal longitude
+        boolean isVisited
 ) {
 
     public static EventSummaryResponse from(CulturalEvent event) {
+        return fromWithVisitStatus(event, false);
+    }
+
+    public static EventSummaryResponse fromWithVisitStatus(CulturalEvent event, boolean isVisited) {
         boolean isFreeEvent = "무료".equals(event.getIsFree());
 
         return new EventSummaryResponse(
@@ -35,14 +37,24 @@ public record EventSummaryResponse(
                 event.getEndDate(),
                 isFreeEvent,
                 event.getMainImg(),
-                event.getLatitude(),
-                event.getLongitude()
+                isVisited
         );
     }
 
     public static List<EventSummaryResponse> fromList(List<CulturalEvent> events) {
         return events.stream()
                 .map(EventSummaryResponse::from)
+                .toList();
+    }
+
+    public static List<EventSummaryResponse> fromListWithVisitStatus(
+            List<CulturalEvent> events,
+            List<Long> visitedEventIds) {
+
+        return events.stream()
+                .map(event -> fromWithVisitStatus(
+                        event,
+                        visitedEventIds.contains(event.getId())))
                 .toList();
     }
 }

--- a/src/main/java/com/moonbaar/domain/visit/repository/VisitRepository.java
+++ b/src/main/java/com/moonbaar/domain/visit/repository/VisitRepository.java
@@ -20,6 +20,11 @@ public interface VisitRepository extends JpaRepository<Visit, Long> {
 
     Optional<Visit> findTopByUserAndEventOrderByVisitedAtDesc(User user, CulturalEvent event);
 
+    @Query("SELECT v.event.id FROM Visit v WHERE v.user.id = :userId AND v.event.id IN :eventIds")
+    List<Long> findVisitedEventIdsByUserIdAndEventIdsIn(
+            @Param("userId") Long userId,
+            @Param("eventIds") List<Long> eventIds);
+
     @Query("SELECT v FROM Visit v JOIN FETCH v.event WHERE v.user = :user AND v.visitedAt >= :startDateTime")
     Page<Visit> findByUserAndVisitedAtAfter(@Param("user") User user,
                                             @Param("startDateTime") LocalDateTime startDateTime,

--- a/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
+++ b/src/test/java/com/moonbaar/domain/event/service/EventServiceTest.java
@@ -8,7 +8,6 @@ import com.moonbaar.common.exception.BusinessException;
 import com.moonbaar.domain.category.entity.Category;
 import com.moonbaar.domain.district.entity.District;
 import com.moonbaar.domain.event.dto.EventDetailResponse;
-import com.moonbaar.domain.event.dto.EventUserStatusResponse;
 import com.moonbaar.domain.event.entity.CulturalEvent;
 import com.moonbaar.domain.event.exeption.EventErrorCode;
 import com.moonbaar.domain.event.exeption.EventNotFoundException;
@@ -132,75 +131,5 @@ class EventServiceTest {
         assertThatThrownBy(() -> eventService.getEventDetail(nonExistingId))
                 .isInstanceOf(BusinessException.class)
                 .hasFieldOrPropertyWithValue("errorCode", EventErrorCode.EVENT_NOT_FOUND);
-    }
-
-    @Test
-    @DisplayName("유저와 이벤트 아이디로 이벤트 상태 정보를 조회할 수 있다")
-    void getUserEventStatus_ReturnsCorrectStatus() {
-        // given
-        when(eventProvider.getEventById(EVENT_ID)).thenReturn(testEvent);
-        when(visitRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(true);
-        when(likedEventRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(true);
-
-        // when
-        EventUserStatusResponse response = eventService.getUserEventStatus(testUser, EVENT_ID);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.eventId()).isEqualTo(EVENT_ID);
-        assertThat(response.isVisited()).isTrue();
-        assertThat(response.isLiked()).isTrue();
-    }
-
-    @Test
-    @DisplayName("좋아요와 방문을 하지 않은 이벤트는 false로 표시된다")
-    void getUserEventStatus_WithNoInteractions_ReturnsFalse() {
-        // given
-        when(eventProvider.getEventById(EVENT_ID)).thenReturn(testEvent);
-        when(visitRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(false);
-        when(likedEventRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(false);
-
-        // when
-        EventUserStatusResponse response = eventService.getUserEventStatus(testUser, EVENT_ID);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.eventId()).isEqualTo(EVENT_ID);
-        assertThat(response.isVisited()).isFalse();
-        assertThat(response.isLiked()).isFalse();
-    }
-
-    @Test
-    @DisplayName("방문만 한 이벤트는 isVisited만 true로 표시된다")
-    void getUserEventStatus_WithOnlyVisit_ReturnsCorrectStatus() {
-        // given
-        when(eventProvider.getEventById(EVENT_ID)).thenReturn(testEvent);
-        when(visitRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(true);
-        when(likedEventRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(false);
-
-        // when
-        EventUserStatusResponse response = eventService.getUserEventStatus(testUser, EVENT_ID);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.isVisited()).isTrue();
-        assertThat(response.isLiked()).isFalse();
-    }
-
-    @Test
-    @DisplayName("좋아요만 한 이벤트는 isLiked만 true로 표시된다")
-    void getUserEventStatus_WithOnlyLike_ReturnsCorrectStatus() {
-        // given
-        when(eventProvider.getEventById(EVENT_ID)).thenReturn(testEvent);
-        when(visitRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(false);
-        when(likedEventRepository.existsByUserAndEvent(testUser, testEvent)).thenReturn(true);
-
-        // when
-        EventUserStatusResponse response = eventService.getUserEventStatus(testUser, EVENT_ID);
-
-        // then
-        assertThat(response).isNotNull();
-        assertThat(response.isVisited()).isFalse();
-        assertThat(response.isLiked()).isTrue();
     }
 }


### PR DESCRIPTION
## 이슈
- #67
- #26 

## 주요 변경사항
- `/events/with-status` 및 `/events/with-status/{eventId}` 엔드포인트를 구현하였습니다.
- 두 엔드포인트 모두 인증이 필요하며, 인증된 유저의 경우 `isVisited`, `isLiked` 값이 실제 사용자 데이터를 기반으로 반환됩니다.
- 행사 리스트 응답에 longitude, latitude 필드를 제거했습니다.

## 상세 구현 설명
기존 구조를 크게 벗어나지 않게 구현을 했지만 리팩토링이 필요해 보입니다.

`/events/with-status`: 
  1. 전체 행사 목록을 조회한 후,
  2. 로그인 유저의 방문 행사 ID 리스트를 가져오고,
  3. 각 이벤트가 이 리스트에 포함되는지 확인하여 `isVisited` 값을 채웁니다.
  
  현재 로직은 비교적 단순하지만, `contains` 체크가 반복되기 때문에 대규모 데이터에 대해 성능 이슈가 있을 수 있습니다. 추후 개선이 필요해 보입니다.

`/events/with-status/{eventId}`:
  - 방문 수, 좋아요 수, 방문 여부, 좋아요 여부를 각각 개별 쿼리로 조회하고 있습니다.
  - 추후 단일 쿼리 또는 병렬 쿼리 처리 방식으로 최적화 가능성이 있습니다.

## 개선 포인트
- `/events/with-status`의 `isVisited` 처리 로직을 더 효율적으로 개선할 수 있는 방법 (e.g. Map 기반 처리, SQL 단일 쿼리화, QueryDSL 사용) 을 검토할 예정입니다.
- `/events/with-status/{eventId}`의 통계 정보도 서브쿼리 통합 등을 통해 최적화 여지가 있습니다.

## API 명세
###  /events/with-status
|항목 | 내용|
|-- | --|
엔드포인트 | /events/with-status
메서드 | GET
설명 | 문화행사 목록 조회 및 검색 (페이징, 필터링, 검색 지원)
쿼리 파라미터 | query: 검색어 (선택적)<br>page: 페이지 번호 (기본값: 1)<br>size: 페이지 크기 (기본값: 20)<br>categoryId: 카테고리 ID<br>districtId: 행정구역 ID<br>startDate: 시작 날짜 (YYYY-MM-DD)<br>endDate: 종료 날짜 (YYYY-MM-DD)<br>isFree: 무료 여부 (true/false)<br>order: 정렬 순서 (asc, desc) |  
인증 | 필요
오류 코드 | 404: 행사 정보 없음
응답 | |

```json
{
  "totalCount": 324,
  "totalPages": 17,
  "currentPage": 1,
  "events": [
    {
      "id": "이벤트ID",
      "title": "행사명",
      "category": "카테고리",
      "district": "행정구역",
      "place": "장소명",
      "startDate": "2025-04-10T10:00:00Z",
      "endDate": "2025-04-10T18:00:00Z",
      "isFree": true,
      "mainImg": "이미지URL",
      "isVisited": true
    },
   ...
  ]
}
```

###  /events/with-status/{eventId}

|항목 | 내용|
|-- | --|
엔드포인트 | /events/with-status/{eventId}
메서드 | GET
설명 | 특정 문화행사의 상세 정보 조회
URL 파라미터 | eventId: 행사 ID
인증 | 필요
오류 코드 | 404: 행사 정보 없음
응답 | 

```json
{
  "id": "이벤트ID",
  "title": "행사명",
  "category": "카테고리",
  "district": "행정구역",
  "place": "장소명",
  "startDate": "2025-04-10T10:00:00Z",
  "endDate": "2025-04-10T18:00:00Z",
  "isFree": true,
  "useFee": "요금 정보",
  "useTarget": "이용대상",
  "program": "프로그램 소개",
  "etcDesc": "상세 설명",
  "mainImg": "이미지URL",
  "orgName": "주최자명",
  "orgLink": "기관 URL",
  "hmpgAddr": "홈페이지 주소",
  "latitude": 37.5665,
  "longitude": 126.978,
  "visitCount": 42,
  "likeCount": 18,
  "isVisited": true,
  "isLiked": true
}
```


