### PR TITLE
feat: oauth2 인증 성공 redirect url 동적으로 생성하기 및 프론트엔드 서버 프록시 설정

### DIFF
--- a/docker-files/nginx/nginx.conf.template
+++ b/docker-files/nginx/nginx.conf.template
@@ -23,7 +23,7 @@ server {
     # 프론트엔드 요청은 Netlify로 프록시
     location / {
         proxy_pass https://moonbaar.netlify.app/;
-        proxy_set_header Host your-netlify-site.netlify.app;
+        proxy_set_header Host moonbaar.netlify.app;
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;

--- a/docker-files/nginx/nginx.conf.template
+++ b/docker-files/nginx/nginx.conf.template
@@ -11,9 +11,21 @@ server {
     ssl_certificate ${SSL_CERT_PATH};
     ssl_certificate_key ${SSL_CERT_KEY};
 
-    location / {
-        proxy_pass http://backend:8080;
+    # 백엔드 API 요청 처리
+    location /api/ {
+        proxy_pass http://backend:8080/api/;
         proxy_set_header Host $host;
         proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    # 프론트엔드 요청은 Netlify로 프록시
+    location / {
+        proxy_pass https://moonbaar.netlify.app/;
+        proxy_set_header Host your-netlify-site.netlify.app;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
     }
 }

--- a/src/main/java/com/moonbaar/common/config/OAuth2Config.java
+++ b/src/main/java/com/moonbaar/common/config/OAuth2Config.java
@@ -1,0 +1,14 @@
+package com.moonbaar.common.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+
+@Configuration
+public class OAuth2Config {
+
+    @Bean
+    public HttpSessionOAuth2AuthorizationRequestRepository httpSessionOAuth2AuthorizationRequestRepository() {
+        return new HttpSessionOAuth2AuthorizationRequestRepository();
+    }
+}

--- a/src/main/java/com/moonbaar/common/config/SecurityConfig.java
+++ b/src/main/java/com/moonbaar/common/config/SecurityConfig.java
@@ -1,6 +1,7 @@
 package com.moonbaar.common.config;
 
 import com.moonbaar.common.filter.JwtAuthenticationFilter;
+import com.moonbaar.common.oauth.CustomAuthorizationRequestRepository;
 import com.moonbaar.common.oauth.handler.OAuth2SuccessHandler;
 import jakarta.servlet.http.HttpServletResponse;
 import java.util.Arrays;
@@ -26,6 +27,7 @@ public class SecurityConfig {
     private final CorsProperties corsProperties;
     private final OAuth2UserService<OAuth2UserRequest, OAuth2User> customOAuth2UserService;
     private final OAuth2SuccessHandler oAuth2SuccessHandler;
+    private final CustomAuthorizationRequestRepository customAuthorizationRequestRepository;
     private final JwtAuthenticationFilter jwtAuthenticationFilter;
 
     @Bean
@@ -51,6 +53,9 @@ public class SecurityConfig {
                 )
 
                 .oauth2Login(oauth -> oauth
+                        .authorizationEndpoint(auth -> auth
+                                .authorizationRequestRepository(customAuthorizationRequestRepository)
+                        )
                         // 로그인 후 사용자 정보 가져올 때 사용할 서비스 지정
                         .userInfoEndpoint(userInfo -> userInfo .userService(customOAuth2UserService))
                         .successHandler(oAuth2SuccessHandler)

--- a/src/main/java/com/moonbaar/common/oauth/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/com/moonbaar/common/oauth/CustomAuthorizationRequestRepository.java
@@ -1,0 +1,54 @@
+package com.moonbaar.common.oauth;
+
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
+import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
+import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CustomAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
+
+    private final HttpSessionOAuth2AuthorizationRequestRepository defaultRepo =
+            new HttpSessionOAuth2AuthorizationRequestRepository();
+
+    private static final String REDIRECT_URI_PARAM = "final_redirect_uri";
+
+    @Override
+    public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
+        return defaultRepo.loadAuthorizationRequest(request);
+    }
+
+    @Override
+    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
+                                         HttpServletRequest request, HttpServletResponse response) {
+        // redirect_uri 쿼리 파라미터 읽기
+        String redirectUri = request.getParameter("redirect_uri");
+        if (redirectUri != null) {
+            // 세션에 직접 저장
+            request.getSession().setAttribute(REDIRECT_URI_PARAM, redirectUri);
+        }
+        defaultRepo.saveAuthorizationRequest(authorizationRequest, request, response);
+    }
+
+    @Override
+    public OAuth2AuthorizationRequest removeAuthorizationRequest(HttpServletRequest request,
+                                                                 HttpServletResponse response) {
+        return defaultRepo.removeAuthorizationRequest(request, response);
+    }
+
+    /**
+     * 리다이렉트 URI를 가져오는 새로운 메서드
+     */
+    public String extractRedirectUri(HttpServletRequest request) {
+        return (String) request.getSession().getAttribute(REDIRECT_URI_PARAM);
+    }
+
+    /**
+     * 세션에서 리다이렉트 URI를 제거하는 메서드
+     */
+    public void removeRedirectUri(HttpServletRequest request) {
+        request.getSession().removeAttribute(REDIRECT_URI_PARAM);
+    }
+}

--- a/src/main/java/com/moonbaar/common/oauth/CustomAuthorizationRequestRepository.java
+++ b/src/main/java/com/moonbaar/common/oauth/CustomAuthorizationRequestRepository.java
@@ -2,18 +2,24 @@ package com.moonbaar.common.oauth;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import java.net.URI;
+import java.net.URISyntaxException;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.oauth2.client.web.AuthorizationRequestRepository;
 import org.springframework.security.oauth2.client.web.HttpSessionOAuth2AuthorizationRequestRepository;
 import org.springframework.security.oauth2.core.endpoint.OAuth2AuthorizationRequest;
 import org.springframework.stereotype.Component;
 
+@Slf4j
 @Component
+@RequiredArgsConstructor
 public class CustomAuthorizationRequestRepository implements AuthorizationRequestRepository<OAuth2AuthorizationRequest> {
 
-    private final HttpSessionOAuth2AuthorizationRequestRepository defaultRepo =
-            new HttpSessionOAuth2AuthorizationRequestRepository();
-
     private static final String REDIRECT_URI_PARAM = "final_redirect_uri";
+    private static final String DEFAULT_REDIRECT_PATH = "/login-success";
+
+    private final HttpSessionOAuth2AuthorizationRequestRepository defaultRepo;
 
     @Override
     public OAuth2AuthorizationRequest loadAuthorizationRequest(HttpServletRequest request) {
@@ -21,14 +27,13 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
     }
 
     @Override
-    public void saveAuthorizationRequest(OAuth2AuthorizationRequest authorizationRequest,
-                                         HttpServletRequest request, HttpServletResponse response) {
-        // redirect_uri 쿼리 파라미터 읽기
-        String redirectUri = request.getParameter("redirect_uri");
-        if (redirectUri != null) {
-            // 세션에 직접 저장
-            request.getSession().setAttribute(REDIRECT_URI_PARAM, redirectUri);
-        }
+    public void saveAuthorizationRequest(
+            OAuth2AuthorizationRequest authorizationRequest,
+            HttpServletRequest request,
+            HttpServletResponse response) {
+
+        String finalRedirectUri = determineRedirectUri(request);
+        storeRedirectUri(request, finalRedirectUri);
         defaultRepo.saveAuthorizationRequest(authorizationRequest, request, response);
     }
 
@@ -38,17 +43,38 @@ public class CustomAuthorizationRequestRepository implements AuthorizationReques
         return defaultRepo.removeAuthorizationRequest(request, response);
     }
 
-    /**
-     * 리다이렉트 URI를 가져오는 새로운 메서드
-     */
     public String extractRedirectUri(HttpServletRequest request) {
-        return (String) request.getSession().getAttribute(REDIRECT_URI_PARAM);
+        String finalRedirectUri = (String) request.getSession().getAttribute(REDIRECT_URI_PARAM);
+        request.getSession().removeAttribute(REDIRECT_URI_PARAM);
+        return finalRedirectUri;
     }
 
-    /**
-     * 세션에서 리다이렉트 URI를 제거하는 메서드
-     */
-    public void removeRedirectUri(HttpServletRequest request) {
-        request.getSession().removeAttribute(REDIRECT_URI_PARAM);
+    private String determineRedirectUri(HttpServletRequest request) {
+        String referer = request.getHeader("Referer");
+        if (referer == null || referer.isEmpty()) {
+            return "/";
+        }
+
+        try {
+            String domain = extractDomain(referer);
+            log.info("Referer 헤더에서 추출한 domain: {}", domain);
+            return domain + DEFAULT_REDIRECT_PATH;
+        } catch (URISyntaxException e) {
+            log.error("Referer 헤더에서 도메인 추출 실패: {}", referer, e);
+            return "/";
+        }
+    }
+
+    private void storeRedirectUri(HttpServletRequest request, String redirectUri) {
+        request.getSession().setAttribute(REDIRECT_URI_PARAM, redirectUri);
+    }
+
+    private String extractDomain(String url) throws URISyntaxException {
+        URI uri = new URI(url);
+        String domain = uri.getScheme() + "://" + uri.getHost();
+        if (uri.getPort() != -1) {
+            domain += ":" + uri.getPort();
+        }
+        return domain;
     }
 }

--- a/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,5 @@
 package com.moonbaar.common.oauth.handler;
 
-import com.moonbaar.common.config.CorsProperties;
 import com.moonbaar.common.oauth.CustomAuthorizationRequestRepository;
 import com.moonbaar.common.oauth.CustomOAuth2User;
 import com.moonbaar.common.utils.JwtUtils;
@@ -23,13 +22,9 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
 
-    private final CorsProperties corsProperties;
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
     private final CustomAuthorizationRequestRepository authorizationRequestRepository;
-
-    @Value("${frontend.redirect-url}")
-    private String redirectUrl;
 
     @Value("${jwt.access-token-expiration}")
     private long accessTokenExpirationMs;
@@ -72,15 +67,9 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessCookie);
         response.addCookie(refreshCookie);
 
-        String redirectUri = "/";
         String finalRedirectUri = authorizationRequestRepository.extractRedirectUri(request);
-        if (finalRedirectUri != null && !finalRedirectUri.isBlank()) {
-            redirectUri = finalRedirectUri;
-            // 사용 후 세션에서 제거
-            authorizationRequestRepository.removeRedirectUri(request);
-            System.out.println("세션에서 가져온 redirect_uri: " + redirectUri);
-        }
+        log.info("세션에서 가져온 redirect_uri: {}", finalRedirectUri);
 
-        response.sendRedirect(redirectUri + "/login-success");
+        response.sendRedirect(finalRedirectUri);
     }
 }

--- a/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
+++ b/src/main/java/com/moonbaar/common/oauth/handler/OAuth2SuccessHandler.java
@@ -1,6 +1,7 @@
 package com.moonbaar.common.oauth.handler;
 
 import com.moonbaar.common.config.CorsProperties;
+import com.moonbaar.common.oauth.CustomAuthorizationRequestRepository;
 import com.moonbaar.common.oauth.CustomOAuth2User;
 import com.moonbaar.common.utils.JwtUtils;
 import com.moonbaar.domain.user.entity.User;
@@ -25,6 +26,7 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
     private final CorsProperties corsProperties;
     private final JwtUtils jwtUtils;
     private final UserRepository userRepository;
+    private final CustomAuthorizationRequestRepository authorizationRequestRepository;
 
     @Value("${frontend.redirect-url}")
     private String redirectUrl;
@@ -70,6 +72,15 @@ public class OAuth2SuccessHandler implements AuthenticationSuccessHandler {
         response.addCookie(accessCookie);
         response.addCookie(refreshCookie);
 
-        response.sendRedirect(redirectUrl);
+        String redirectUri = "/";
+        String finalRedirectUri = authorizationRequestRepository.extractRedirectUri(request);
+        if (finalRedirectUri != null && !finalRedirectUri.isBlank()) {
+            redirectUri = finalRedirectUri;
+            // 사용 후 세션에서 제거
+            authorizationRequestRepository.removeRedirectUri(request);
+            System.out.println("세션에서 가져온 redirect_uri: " + redirectUri);
+        }
+
+        response.sendRedirect(redirectUri + "/login-success");
     }
 }


### PR DESCRIPTION
## 이슈
- #60 

## 변경 사항
- 인증 request를 기반으로 생성한 redirect uri를 세션에 저장하기 위해 CustomAuthorizationRequestRepository를 구현했습니다.
- OAuth2SuccessHandler에서 세션에 저장된 final_redirect_uri를 사용하도록 수정했습니다.
<img width="601" alt="image" src="https://github.com/user-attachments/assets/d58c515d-2016-4a9e-9abc-9059d9c44c72" />

- nginx 컨테이너에서 "/api"를 제외한 요청은 프론트엔드 서버로 프록시 하도록 설정했습니다.
- allowed origins에 배포 도메인을 추가했습니다.

## 세부 설명
- Spring Security의 OAuth2는 기본적으로 인증 요청을 HTTP 세션에 저장하고 관리하는데, 이를 확장하여 `final_redirect_uri` attribute를 세션에 저장했습니다.
- 클라이언트의 인증 요청이 백엔드 서버로 오면 referer 헤더에서 도메인을 추출해 redirect uri를 만들어 세션에 저장합니다.
<img width="542" alt="image" src="https://github.com/user-attachments/assets/b259a6b6-4543-4ba9-b3d1-6313d74d8980" />

- OAuth 인증 요청은 이미 CORS 검증을 통과한 상태이므로, 별도의 도메인 검증 과정은 생략했습니다.
- 인증 성공 시 OAuth2SuccessHandler에서 세션에 저장된 리다이렉션 URI를 사용하여 사용자를 원래 요청한 클라이언트로 리다이렉션합니다.
- 이전에 `redirect_uri` attribute를 사용했으나 실패했었는데, 해당 attribute가 OAuth2 provider에서 이미 사용 중이었기 때문인 것으로 보입니다. `state`나 `redirect_uri` 파라미터는 기본적으로 oauth2 provider가 사용하는 파라미터입니다. 이를 피해 `final_redirect_uri`로 attribute명을 설정했습니다.