### PR TITLE
fix: 발자국 response id 오류 수정

### DIFF
--- a/src/main/java/com/moonbaar/domain/visit/dto/FootprintResponse.java
+++ b/src/main/java/com/moonbaar/domain/visit/dto/FootprintResponse.java
@@ -19,7 +19,7 @@ public record FootprintResponse(
         CulturalEvent event = visit.getEvent();
 
         return new FootprintResponse(
-                visit.getId(),
+                event.getId(),
                 event.getTitle(),
                 event.getPlace(),
                 event.getMainImg(),


### PR DESCRIPTION
## 이슈
- #73 

## 설명
- 행사의 id가 아니라 방문기록의 id가 돌아가고 있던 문제 해결